### PR TITLE
Add 'let' to top level definitions; infer breaks using top-level keywords

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -741,13 +741,13 @@ defn_test_() ->
                        versions=[#alpaca_fun_version{
                                     args=[], 
                                     body={int, 1, 5}}]}},
-                   parse(alpaca_scanner:scan("x=5"))),
+                   parse(alpaca_scanner:scan("let x=5"))),
      ?_assertMatch(
         {ok, {error, non_literal_value, {symbol, 1, "x"}, 
                      {alpaca_apply,undefined,1,
                        {symbol,1,"sideEffectingFun"},
                        [{int,1,5}]}}},
-        parse(alpaca_scanner:scan("x=sideEffectingFun 5"))),
+        parse(alpaca_scanner:scan("let x=sideEffectingFun 5"))),
      ?_assertMatch(
         {ok, {error, non_literal_value, {symbol, 1, "x"},                  
                          {alpaca_record,2,1,false,
@@ -757,7 +757,7 @@ defn_test_() ->
                                   {alpaca_apply,undefined,1,
                                       {symbol,1,"sideEffectingFun"},
                                       [{int,1,5}]}}]}}},
-        parse(alpaca_scanner:scan("x={one = 10, two = (sideEffectingFun 5)}"))),        
+        parse(alpaca_scanner:scan("let x={one = 10, two = (sideEffectingFun 5)}"))),        
      ?_assertMatch(
         {ok, {error, non_literal_value, {symbol, 1, "x"}, 
                      {alpaca_cons,undefined,0,
@@ -767,7 +767,7 @@ defn_test_() ->
                                      {symbol,1,"sideEffectingFun"},
                                      [{int,1,5}]},
                                  {nil,0}}}}},
-        parse(alpaca_scanner:scan("x=[1, (sideEffectingFun 5)]"))),        
+        parse(alpaca_scanner:scan("let x=[1, (sideEffectingFun 5)]"))),        
      ?_assertMatch(
         {ok, 
          #alpaca_fun_def{name={symbol, 1, "double"},
@@ -778,7 +778,7 @@ defn_test_() ->
                                             expr={bif, '+', 1, erlang, '+'},
                                             args=[{symbol, 1, "x"},
                                                   {symbol, 1, "x"}]}}]}},
-        parse(alpaca_scanner:scan("double x = x + x"))),
+        parse(alpaca_scanner:scan("let double x = x + x"))),
      ?_assertMatch(
         {ok, #alpaca_fun_def{name={symbol, 1, "add"},
                            versions=[#alpaca_fun_version{
@@ -789,7 +789,7 @@ defn_test_() ->
                                                 expr={bif, '+', 1, erlang, '+'},
                                                 args=[{symbol, 1, "x"},
                                                       {symbol, 1, "y"}]}}]}},
-        parse(alpaca_scanner:scan("add x y = x + y"))),
+        parse(alpaca_scanner:scan("let add x y = x + y"))),
         ?_assertMatch(
             {ok, #alpaca_fun_def{name={symbol, 1, "(<*>)"},
                             versions=[#alpaca_fun_version{
@@ -800,7 +800,7 @@ defn_test_() ->
                                                     expr={bif, '+', 1, erlang, '+'},
                                                     args=[{symbol, 1, "x"},
                                                         {symbol, 1, "y"}]}}]}},
-        parse(alpaca_scanner:scan("(<*>) x y = x + y")))
+        parse(alpaca_scanner:scan("let (<*>) x y = x + y")))
     ].
 
 float_math_test_() ->
@@ -856,7 +856,7 @@ let_binding_test_() ->
                                          expr={symbol, 3, "double"},
                                          args=[{int, 3, 2}]}}}]}},
         parse(alpaca_scanner:scan(
-                "doubler x =\n"
+                "let doubler x =\n"
                 "  let double x = x + x in\n"
                 "  double 2"))),
      ?_assertMatch(
@@ -895,7 +895,7 @@ let_binding_test_() ->
                                                           expr={symbol,1,"yer"},
                                                           args=[{symbol,1,"y"}]}]}}}}]}},
         parse(alpaca_scanner:scan(
-                "my_fun x y ="
+                "let my_fun x y ="
                 "  let xer a = a + a in"
                 "  let yer b = b + b in"
                 "  (xer x) + (yer y)")))
@@ -958,7 +958,7 @@ module_with_let_test() ->
     Code =
         "module test_mod\n\n"
         "export add/2\n\n"
-        "add x y =\n"
+        "let add x y =\n"
         "  let adder a b = a + b in\n"
         "  adder x y",
     ?assertMatch(

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1232,22 +1232,22 @@ break_test() ->
 
 rebinding_test_() ->
     %% Simple rebinding:
-    {ok, A} = test_parse("f x = let y = 2 in x + y"),
+    {ok, A} = test_parse("let f x = let y = 2 in x + y"),
     %% Check for duplicate definition error:
-    {ok, B} = test_parse("f x = \nlet x = 1 in x + x"),
+    {ok, B} = test_parse("let f x = \nlet x = 1 in x + x"),
     %% Check for good pattern match variable names:
-    {ok, C} = test_parse("f x = match x with\n"
+    {ok, C} = test_parse("let f x = match x with\n"
                          "  (a, 0) -> a\n"
                          "| (a, b) -> b"),
     %% Check for duplication in pattern match variable names:
-    {ok, D} = test_parse("f x = match x with\n"
+    {ok, D} = test_parse("let f x = match x with\n"
                          " x -> 0"),
     %% Check for good pattern match variable names in lists:
-    {ok, E} = test_parse("f x = match x with\n"
+    {ok, E} = test_parse("let f x = match x with\n"
                          "  [_, b, 0] -> b\n"
                          "| h :: t -> h"),
     %% Check for dupe variable names in lists:
-    {ok, F} = test_parse("f x y = match x with\n"
+    {ok, F} = test_parse("let f x y = match x with\n"
                          " h :: y -> h"),
 
     [?_assertMatch({_, _, #alpaca_fun_def{

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1163,10 +1163,10 @@ simple_module_test() ->
     Code =
         "module test_mod\n\n"
         "export add/2, sub/2\n\n"
-        "adder x y = x + y\n\n"
-        "add1 x = adder x 1\n\n"
-        "add x y = adder x y\n\n"
-        "sub x y = x - y",
+        "let adder x y = x + y\n\n"
+        "let add1 x = adder x 1\n\n"
+        "let add x y = adder x y\n\n"
+        "let sub x y = x - y",
     ?assertMatch(
        {ok, _, _,
         #alpaca_module{
@@ -1209,8 +1209,8 @@ simple_module_test() ->
 break_test() ->
     % We should tolerate whitespace between the two break tokens
     Code = "module test_mod\n\n
-            a = 5\n   \n"
-           "b = 6\n\n",
+            let a = 5\n   \n"
+           "let b = 6\n\n",
      ?assertMatch(
        {ok, _, _,
         #alpaca_module{

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -516,18 +516,18 @@ parse_and_gen(Code) ->
 simple_compile_test() ->
     Code =
         "module test_mod\n\n"
-        "export add/2, sub/2\n\n"
-        "add x y = x + y\n\n"
-        "sub x y = x - y\n\n",
+        "export add/2, sub/2\n"
+        "let add x y = x + y\n"
+        "let sub x y = x - y\n",
     {ok, _, _Bin} = parse_and_gen(Code).
 
 module_with_internal_apply_test() ->
     Code =
         "module test_mod\n\n"
         "export add/2\n\n"
-        "adder x y = x + y\n\n"
-        "add x y = adder x y\n\n"
-        "eq x y = x == y",
+        "let adder x y = x + y\n\n"
+        "let add x y = adder x y\n\n"
+        "let eq x y = x == y",
     {ok, _, Bin} = parse_and_gen(Code).
 
 infix_fun_test() ->
@@ -536,9 +536,9 @@ infix_fun_test() ->
     Code =
         "module infix_fun\n\n"
         "export adder/1 \n\n"
-        "(|>) v f = f v\n\n"
-        "add_ten x = x + 10\n\n"
-        "adder val = val |> add_ten",
+        "let (|>) v f = f v\n\n"
+        "let add_ten x = x + 10\n\n"
+        "let adder val = val |> add_ten",
     {ok, _, Bin} = parse_and_gen(Code),
     {module, Name} = code:load_binary(Name, FN, Bin),
     ?assertEqual(20, Name:adder(10)),
@@ -550,7 +550,7 @@ fun_and_var_binding_test() ->
     Code =
         "module fun_and_var_binding\n\n"
         "export test_func/1\n\n"
-        "test_func x =\n"
+        "let test_func x =\n"
         "  let y = x + 2 in\n"
         "  let double z = z + z in\n"
         "  double y",
@@ -565,8 +565,8 @@ value_test() ->
     Code =
         "module value_function\n\n"
         "export test_func/1\n\n"
-        "test_int = 42\n\n"
-        "test_func () =\n"
+        "let test_int = 42\n\n"
+        "let test_func () =\n"
         "  test_int\n\n",
 
     {ok, _, Bin} = parse_and_gen(Code),
@@ -580,7 +580,7 @@ unit_function_test() ->
     Code =
         "module unit_function\n\n"
         "export test_func/1\n\n"
-        "test_func x =\n"
+        "let test_func x =\n"
         "  let y () = 5 in\n"
         "  let z = 3 in\n"
         "  x + ((y ()) + z)",
@@ -593,7 +593,7 @@ parser_nested_letrec_test() ->
     Code =
         "module test_mod\n\n"
         "export add/2\n\n"
-        "add x y =\n"
+        "let add x y =\n"
         "  let adder1 a b = a + b in\n"
         "  let adder2 c d = adder1 c d in\n"
         "  adder2 x y",
@@ -606,16 +606,16 @@ module_with_match_test() ->
     Code =
         "module compile_module_with_match\n\n"
         "export check/1, first/1, compare/2\n\n"
-        "check x = match x with\n"
+        "let check x = match x with\n"
         "  0 -> :zero\n"
         "| 1 -> :one\n"
         "| _ -> :more_than_one\n\n"
-        "first t =\n"
+        "let first t =\n"
         "  match t with\n"
         "    (f, _) -> f\n"
         "  | _ -> :not_a_2_tuple\n\n"
     %% This is the failing section in particular:
-        "compare x y = match x with\n"
+        "let compare x y = match x with\n"
         "  a, a == y -> :matched\n"
         "| _ -> :not_matched",
     {ok, _, Bin} = parse_and_gen(Code),
@@ -633,11 +633,11 @@ cons_test() ->
     Code =
         "module compiler_cons_test\n\n"
         "export make_list/2, my_map/2\n\n"
-        "make_list h t =\n"
+        "let make_list h t =\n"
         "  match t with\n"
         "    a :: b -> h :: t\n"
         "  | term -> h :: term :: []\n\n"
-        "my_map f x =\n"
+        "let my_map f x =\n"
         "  match x with\n"
         "    [] -> []\n"
         "  | h :: t -> (f h) :: (my_map f t)",
@@ -653,11 +653,11 @@ call_test() ->
     Code1 =
         "module call_test_a\n\n"
         "export a/1\n\n"
-        "a x = call_test_b.add x 1",
+        "let a x = call_test_b.add x 1",
     Code2 =
         "module call_test_b\n\n"
         "export add/2\n\n"
-        "add x y = x + y",
+        "let add x y = x + y",
 
     {ok, _, Bin1} = parse_and_gen(Code1),
     {ok, _, Bin2} = parse_and_gen(Code2),
@@ -675,7 +675,7 @@ ffi_test() ->
     Code =
         "module ffi_test\n\n"
         "export a/1\n\n"
-        "a x = beam :erlang :list_to_integer [x] with\n"
+        "let a x = beam :erlang :list_to_integer [x] with\n"
         "  1 -> :one\n"
         "| _ -> :not_one\n",
     {ok, _, Bin} = parse_and_gen(Code),
@@ -693,7 +693,7 @@ type_guard_test() ->
     Code =
         "module type_guard_test\n\n"
         "export check/1\n\n"
-        "check x = \n"
+        "let check x = \n"
         "beam :erlang :* [x, x] with\n"
         "   i, is_integer i -> i\n"
         " | f -> 0",
@@ -711,7 +711,7 @@ multi_type_guard_test() ->
     Code =
         "module multi_type_guard_test\n\n"
         "export check/1\n\n"
-        "check x = \n"
+        "let check x = \n"
         "beam :erlang :* [x, x] with\n"
         "   i, is_integer i, i == 4 -> :got_four\n"
         " | i, is_integer i, i > 5, i < 20 -> :middle\n"

--- a/src/alpaca_format.alp
+++ b/src/alpaca_format.alp
@@ -6,16 +6,16 @@ import_type alpaca_native_ast.ast
 
 import_type alpaca_native_ast.symbol
 
-format ast_node = format_ast 0 ast_node
+let format ast_node = format_ast 0 ast_node
 
-max_len = 80
+let max_len = 80
 
-format_ast depth Symbol {name=name} =
+let format_ast depth Symbol {name=name} =
   let end_of_line = depth + (s_len name) in
   (end_of_line, name)
        
 --format depth Apply (sym, _) =
 
-s_len s = beam :string :len [s] with
+let s_len s = beam :string :len [s] with
   l, is_integer l -> l
   

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -377,7 +377,7 @@ spawn_pid -> spawn symbol terms:
 
 defn -> let terms assign simple_expr : make_define('$2', '$4', 'top').
 definfix -> let '(' infixable ')' terms assign simple_expr : 
-  {infixable, L, C} = '$2',
+  {infixable, L, C} = '$3',
   make_define([{symbol, L, "(" ++ C ++ ")"}] ++ '$5', '$7', 'top').
 
 binding -> let defn in simple_expr : make_binding('$2', '$4').

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -375,10 +375,10 @@ spawn_pid -> spawn symbol terms:
               function='$2',
               args='$3'}.
 
-defn -> terms assign simple_expr : make_define('$1', '$3', 'top').
-definfix -> '(' infixable ')' terms assign simple_expr : 
+defn -> let terms assign simple_expr : make_define('$2', '$4', 'top').
+definfix -> let '(' infixable ')' terms assign simple_expr : 
   {infixable, L, C} = '$2',
-  make_define([{symbol, L, "(" ++ C ++ ")"}] ++ '$4', '$6', 'top').
+  make_define([{symbol, L, "(" ++ C ++ ")"}] ++ '$5', '$7', 'top').
 
 binding -> let defn in simple_expr : make_binding('$2', '$4').
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -152,7 +152,7 @@ _    : {token, {'_', TokenLine}}.
 
 %% Whitespace ignore
 {WS} : skip_token.
-{BRK} : {token, {break, TokenLine}}.
+\;\; : {token, {break, TokenLine}}.
 
 %% Comments
 --[^\n]* :

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -9,7 +9,9 @@
 
 scan(Code) ->    
     %% Scan and infer break tokens if not provided
-    case alpaca_scan:string(Code) of
+    {ok, Re} = re:compile("\n([ \t]+)\n", [unicode]),
+    Sanitized = re:replace(Code, Re, "\n\n", [{return,list},global]),
+    case alpaca_scan:string(Sanitized) of
         {ok, Tokens, Num} -> {ok, infer_breaks(Tokens), Num};    
         Error -> Error
     end.

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -123,4 +123,16 @@ infer_test() ->
                       ],                       
     ?assertEqual({ok, ExpectedTokens, 3}, scan(Code)).
 
+infer_bin_test() ->
+    Code = "module bin_test\nlet a = << 10 : type = int >>",
+    ExpectedTokens = [{'module', 1}, {symbol, 1, "bin_test"},
+                                      {break, 2},
+                       {'let', 2}, {symbol, 2, "a"}, {assign, 2}, 
+                                   {bin_open, 2}, {int, 2, 10},
+                                   {':', 2}, {type_declare, 2},
+                                   {assign, 2}, {base_type, 2, "int"},
+                                   {bin_close, 2}
+                     ],                       
+    ?assertEqual({ok, ExpectedTokens, 2}, scan(Code)).
+
 -endif.

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -57,6 +57,7 @@ infer_breaks(Tokens) ->
             'export'       -> InferBreak();
             'export_type'  -> InferBreak();
             'import_type'  -> InferBreak();
+            'import'       -> InferBreak();
             _              -> Pass()
         end      
     end,

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -4264,10 +4264,10 @@ types_in_types_test_() ->
                   "module formatter\n\n"
                   "import_type types_in_types.expr\n\n"
                   "import_type types_in_types.ast\n\n"
-                  "format ast_node = format 0 ast_node\n\n"
-                  "format d Match {e=e, clauses=cs} = :match\n\n"
-                  "format d Symbol _ = :symbol\n\n"
-                  "foo () = format 0 Match {e=Symbol \"x\", clauses=[]}",
+                  "let format ast_node = format 0 ast_node\n\n"
+                  "let format d Match {e=e, clauses=cs} = :match\n\n"
+                  "let format d Symbol _ = :symbol\n\n"
+                  "let foo () = format 0 Match {e=Symbol \"x\", clauses=[]}",
               {ok, _, _, M1} = alpaca_ast_gen:parse_module(0, AstCode),
               {ok, _, _, M2} = alpaca_ast_gen:parse_module(0, FormatterCode),
               
@@ -4287,14 +4287,14 @@ types_in_types_test_() ->
               
               %% Importing `symbol` should let us use the constructor:
               FormatterCode = 
-                  "module formatter\n\n"
-                  "import_type types_in_types.symbol\n\n"
-                  "import_type types_in_types.expr\n\n"
+                  "module formatter\n"
+                  "import_type types_in_types.symbol\n"
+                  "import_type types_in_types.expr\n"
                   "import_type types_in_types.ast\n\n"
-                  "format ast_node = format 0 ast_node\n\n"
-                  "format d Match {e=e, clauses=cs} = :match\n\n"
-                  "format d Symbol _ = :symbol\n\n"
-                  "foo () = format 0 Match {e=Symbol {name=\"x\"}, clauses=[]}",
+                  "let format ast_node = format 0 ast_node\n\n"
+                  "let format d Match {e=e, clauses=cs} = :match\n\n"
+                  "let format d Symbol _ = :symbol\n\n"
+                  "let foo () = format 0 Match {e=Symbol {name=\"x\"}, clauses=[]}",
               {ok, _, _, M1} = alpaca_ast_gen:parse_module(0, Ast),
               {ok, _, _, M2} = alpaca_ast_gen:parse_module(0, FormatterCode),
               
@@ -4311,7 +4311,7 @@ expression_typing_test_() ->
         top_typ_of("1 2")),
      ?_assertMatch({{t_arrow, [t_unit], t_int}, _}, 
                    top_typ_of(
-                     "g () = "
+                     "let g () = "
                      "let f x = x + x in "
                      "let g () = f in "
                      "(g ()) 2"
@@ -4321,8 +4321,8 @@ expression_typing_test_() ->
 
 no_process_leak_test() ->
     Code =
-        "module no_leaks\n\n"
-        "add a b = a + b",
+        "module no_leaks\n"
+        "let add a b = a + b",
     {ok, _, _, M} = alpaca_ast_gen:parse_module(0, Code),
     ProcessesBefore = length(erlang:processes()),
     ?assertMatch({ok, _}, type_modules([M])),

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -83,7 +83,7 @@ g_type() ->
 g_function() ->
     ?LET({F, Body},
          {g_function_name(), g_function_body()},
-         g_sprinkle_whitespace([F, "()", "=", Body, $\n])).
+         g_sprinkle_whitespace(["let", F, "()", "=", Body, $\n])).
 
 g_function_name() ->
     ?LET(N, pos_integer(), ?LET(Fun, g_sym(N), Fun)).

--- a/test_files/apply_to_expression.alp
+++ b/test_files/apply_to_expression.alp
@@ -2,14 +2,14 @@ module apply_to_expression
 
 export foo/1, uses_fun/1
 
-foo () =
+let foo () =
   let f x = x + x in
   let g () = f in
   (g ()) 2
 
-returns_fun () =
+let returns_fun () =
   let f x = x + x in
   f
 
-uses_fun x =
+let uses_fun x =
   (returns_fun ()) x

--- a/test_files/basic_adt.alp
+++ b/test_files/basic_adt.alp
@@ -11,7 +11,7 @@ type my_list 'x = Cons ('x, my_list 'x) | Nil
 
 type opt 'a = None | Some 'a
 
-len l = match l with
+let len l = match l with
     Nil -> 0
     -- single line comment should be ignored:
   | Cons (_, tail) -> 1 + (len tail)

--- a/test_files/basic_binary.alp
+++ b/test_files/basic_binary.alp
@@ -15,6 +15,6 @@ let first_three_bits bin =
 let utf8_bins () =
   <<"안녕": type=utf8>>
 
-drop_hello bin =
+let drop_hello bin =
   match bin with
     <<"hello": type=utf8, rest: type=utf8>> -> rest

--- a/test_files/basic_binary.alp
+++ b/test_files/basic_binary.alp
@@ -2,17 +2,17 @@ module basic_binary
 
 export count_one_twos/1, first_three_bits/1, utf8_bins/1, drop_hello/1
 
-count_one_twos bin =
+let count_one_twos bin =
   match bin with
       <<1: size=8, 2: size=8, rest: type=binary>> -> 1 + (count_one_twos rest)
     | _ -> 0
 
-first_three_bits bin =
+let first_three_bits bin =
   match bin with
       <<x: size=1 unit=3 type=int, y: type=binary size=1 unit=5>> -> x
     | _ -> 0
 
-utf8_bins () =
+let utf8_bins () =
   <<"안녕": type=utf8>>
 
 drop_hello bin =

--- a/test_files/basic_compile_file.alp
+++ b/test_files/basic_compile_file.alp
@@ -2,4 +2,4 @@ module basic_compile_file
 
 export double/1
 
-double n = n*2
+let double n = n*2

--- a/test_files/basic_map_test.alp
+++ b/test_files/basic_map_test.alp
@@ -4,13 +4,13 @@ export get/2, add/3, test_map/1, test_tuple_key_map/1
 
 type map_result 'x = Ok 'x | NotFound
 
-test_map () = #{:one => 1, :two => 2}
+let test_map () = #{:one => 1, :two => 2}
 
-test_tuple_key_map () =
+let test_tuple_key_map () =
   #{(:one, 1) => "a", (:two, 2) => "b"}
 
-get k m = match m with
+let get k m = match m with
     #{k => v} -> Ok v
   | _ -> NotFound
 
-add k v m = #{k => v | m}
+let add k v m = #{k => v | m}

--- a/test_files/basic_math.alp
+++ b/test_files/basic_math.alp
@@ -2,12 +2,12 @@ module basic_math
 
 export add2/1, add/2, dec/1, dec_alt/1, neg_float/1
 
-add2 x = add x (+2)
+let add2 x = add x (+2)
 
-add x y = x + y
+let add x y = x + y
 
-dec a = a-1
+let dec a = a-1
 
-dec_alt a = a+-1
+let dec_alt a = a+-1
 
-neg_float f = f *. -1.0
+let neg_float f = f *. -1.0

--- a/test_files/basic_module_with_tests.alp
+++ b/test_files/basic_module_with_tests.alp
@@ -2,19 +2,19 @@ module basic_module_with_tests
 
 export add/2, sub/2
 
-add x y = x + y
+let add x y = x + y
 
-sub x y = x - y
+let sub x y = x - y
 
 test "add 2 and 2" = test_equal (add 2 2) 4
 
 test "subtract 2 from 4" = test_equal (sub 4 2) 3
 
-format_msg base x y =
+let format_msg base x y =
   let m = beam :io_lib :format [base, [x, y]] with msg -> msg in
   beam :lists :flatten [m] with msg, is_chars msg -> msg
 
-test_equal x y =
+let test_equal x y =
   match (x == y) with
       true -> :passed
     | false ->

--- a/test_files/basic_pid_test.alp
+++ b/test_files/basic_pid_test.alp
@@ -4,10 +4,10 @@ export pid_fun/1, start_pid_fun/1
 
 type t = Add int | Fetch (pid int)
 
-pid_fun x = receive with
+let pid_fun x = receive with
     Add i -> pid_fun x + i
   | Fetch sender ->
     let sent = send x sender in
                     pid_fun x
 
-start_pid_fun x = spawn pid_fun x
+let start_pid_fun x = spawn pid_fun x

--- a/test_files/circles.alp
+++ b/test_files/circles.alp
@@ -6,10 +6,10 @@ type radius = float
 
 type circle = Circle radius
 
-new r =
+let new r =
   Circle r
 
-area c =
+let area c =
   let pi = 3.14159 in
   match c with
     Circle r -> pi *. (r *. r)

--- a/test_files/comments.alp
+++ b/test_files/comments.alp
@@ -12,7 +12,7 @@ block }
     comment
 -}
 
-double n = n*2
+let double n = n*2
 
 {--}
 {---}

--- a/test_files/error_tests.alp
+++ b/test_files/error_tests.alp
@@ -2,13 +2,13 @@ module error_tests
 
 export raise_throw/1, raise_error/1, raise_exit/1, throw_or_int/1
 
-raise_throw () = throw "this should be a throw"
+let raise_throw () = throw "this should be a throw"
 
-raise_exit () = exit "exit here"
+let raise_exit () = exit "exit here"
 
-raise_error () = error "and an error"
+let raise_error () = error "and an error"
 
-throw_or_int x = match x with
+let throw_or_int x = match x with
     0 -> throw "oh no zero!"
   | _ -> x * 2
   

--- a/test_files/function_pattern_args.alp
+++ b/test_files/function_pattern_args.alp
@@ -4,32 +4,22 @@ export is_zero/1, both_zero/2, make_xy/2, make_y/1, get_x/1, get_opt_x/1
 
 export double_maybe_x/1, doubler/1
 
-is_zero 0 = true
-
-is_zero x = false
-
-both_zero 0 0 = true
-
-both_zero x y = false
-
-make_xy x y = {x=x, y=y}
-
-make_y y = {y=y}
-
-get_x {x=x} = x
+let is_zero 0 = true
+let is_zero x = false
+let both_zero 0 0 = true
+let both_zero x y = false
+let make_xy x y = {x=x, y=y}
+let make_y y = {y=y}
+let get_x {x=x} = x
 
 type option 'a = None | Some 'a
 
-get_opt_x {x=x} = Some x
+let get_opt_x {x=x} = Some x
+let get_opt_x {} = None
+let my_map f None = None
+let my_map f (Some a) = Some (f a)
 
-get_opt_x {} = None
+let double x = x * x
+let doubler x = my_map double (Some x)
 
-my_map f None = None
-
-my_map f (Some a) = Some (f a)
-
-double x = x * x
-
-doubler x = my_map double (Some x)
-
-double_maybe_x rec = my_map double (get_opt_x rec)
+let double_maybe_x rec = my_map double (get_opt_x rec)

--- a/test_files/higher_order_functions.alp
+++ b/test_files/higher_order_functions.alp
@@ -4,12 +4,12 @@ export new/1, lookup/2, insert/3
 
 type option 'x = None | Some 'x
 
-new () =
+let new () =
   let ret k = None in ret
 
-lookup k d = d k
+let lookup k d = d k
 
-insert k v d =
+let insert k v d =
   let d2 k2 =
     match (k2 == k) with
       true  -> Some v

--- a/test_files/list_opts.alp
+++ b/test_files/list_opts.alp
@@ -6,6 +6,6 @@ import_type basic_adt.my_list
 
 import_type basic_adt.opt
 
-head_opt Cons (h, _) = Some h
+let head_opt Cons (h, _) = Some h
 
-head_opt Nil = None
+let head_opt Nil = None

--- a/test_files/multiple_underscore_test.alp
+++ b/test_files/multiple_underscore_test.alp
@@ -2,16 +2,16 @@ module multiple_underscore_test
 
 export list_check/1, map_check/1, tuple_check/1
 
-list_check () =
+let list_check () =
   match [1, 2] with
     _ :: _ -> :list
 
-map_check m =
+let map_check m =
   match m with
       #{:x => _, :y => _, :z => _} -> "all three"
     | #{:x => _, :y => _} -> "just two"
 
-tuple_check t =
+let tuple_check t =
   match t with
     (_, _, _) -> "three"
     

--- a/test_files/polymorphic_record_test.alp
+++ b/test_files/polymorphic_record_test.alp
@@ -2,16 +2,16 @@ module polymorphic_record_test
 
 export with_y/1, with_y_and_throwaway_x/1
 
-f r =
+let f r =
   match r with
     {x=xx} -> (xx + 1, r)
 
-with_y () =
+let with_y () =
   let res = f {x=1, foo="bar"} in
   match res with
     (_, {foo=ff}) -> ff
 
-with_y_and_throwaway_x() =
+let with_y_and_throwaway_x() =
   let res = f {x=1, foo="baz"} in
   match res with
     (_, {x=_, foo=ff}) -> ff

--- a/test_files/radius.alp
+++ b/test_files/radius.alp
@@ -4,11 +4,11 @@ type radius = Radius int
 
 export make_radius/1, radius_to_int/1
 
-make_radius i = 
+let make_radius i = 
   match i with
     x, is_integer x -> Radius x
 
-radius_to_int r = 
+let radius_to_int r = 
   match r with
     Radius i -> i
     

--- a/test_files/record_map_match_order.alp
+++ b/test_files/record_map_match_order.alp
@@ -4,11 +4,11 @@ export check_map/1, check_record/1
 
 type record_map_union = map atom int | {x: int}
 
-get_x rec_or_map =
+let get_x rec_or_map =
   match rec_or_map with
       #{:x => xx} -> xx
     | {x = xx}    -> xx
 
-check_map () = get_x #{:x => 1}
+let check_map () = get_x #{:x => 1}
 
-check_record () = get_x {x=2}
+let check_record () = get_x {x=2}

--- a/test_files/records_with_x.alp
+++ b/test_files/records_with_x.alp
@@ -2,11 +2,11 @@ module records_with_x
 
 export make_xy/2, make_xyz/3, get_x/1, get_x_and_the_record/1
 
-make_xy x y = {x=x, y=y}
+let make_xy x y = {x=x, y=y}
 
-make_xyz x y z = {x=x, y=y, z=z}
+let make_xyz x y z = {x=x, y=y, z=z}
 
-get_x rec =
+let get_x rec =
   match rec with
     {x=x} -> x
 
@@ -19,6 +19,6 @@ get_x rec =
    (int, {x: int, y: int, z: int})
 
 -}
-get_x_and_the_record rec =
+let get_x_and_the_record rec =
   match rec with
     {x=x} -> (x, rec)

--- a/test_files/same_name_diff_arity.alp
+++ b/test_files/same_name_diff_arity.alp
@@ -2,8 +2,8 @@ module same_name_diff_arity
 
 export seq/1
 
-seq x = seq 0 x
+let seq x = seq 0 x
 
-seq current top = match current with
+let seq current top = match current with
     x, x > top -> []
   | x -> x :: (seq (current + 1) top)  

--- a/test_files/simple_example.alp
+++ b/test_files/simple_example.alp
@@ -3,12 +3,12 @@
     module simple_example
 
     -- a basic top-level function:
-    add2 x = x + 2
+    let add2 x = x + 2
 
     -- a basic infix function
-    (|>) x f = f x
+    let (|>) x f = f x
 
-    something_with_let_bindings x =
+    let something_with_let_bindings x =
       -- a function:
       let adder a b = a + b in
       -- a variable (immutable):
@@ -22,10 +22,10 @@
        messages, that increments its state by received integers
        and can be queried for its state
     -}
-    will_be_a_process x = receive with
+    let will_be_a_process x = receive with
         i -> will_be_a_process (x + i)
       | Fetch sender ->
         let sent = send x sender in
         will_be_a_process x
 
-    start_a_process init = spawn will_be_a_process init
+    let start_a_process init = spawn will_be_a_process init

--- a/test_files/simple_records.alp
+++ b/test_files/simple_records.alp
@@ -2,22 +2,22 @@ module simple_records
 
 export fname/1, lname/1, sample_person/1
 
-fname r =
+let fname r =
   match r with
     {fname=f}, is_string f -> f
 
-lname r =
+let lname r =
   match r with
     {lname=l}, is_string l -> l
 
-make_person fname lname =
+let make_person fname lname =
   {fname=fname, lname=lname}
 
 {- Make an example person and extract first and last names in a tuple.
    Purpose here is to ensure everything type checks correctly as well
    as being able to destructure a record.
  -}
-sample_person () =
+let sample_person () =
   let r = make_person "sample" "person" in
   (fname r, lname r)
   

--- a/test_files/string_concat.alp
+++ b/test_files/string_concat.alp
@@ -2,6 +2,6 @@ module string_concat
 
 export hello/1
 
-hello x = beam :string :concat [c"Hello, ", x] with
+let hello x = beam :string :concat [c"Hello, ", x] with
       s, is_chars s -> s
       

--- a/test_files/type_import.alp
+++ b/test_files/type_import.alp
@@ -4,6 +4,6 @@ import_type basic_adt.my_list
 
 export test_output/1
 
-test_output () =
+let test_output () =
   let l = Cons (1, Cons (2, Nil)) in
   basic_adt.len l

--- a/test_files/unexported_adts.alp
+++ b/test_files/unexported_adts.alp
@@ -16,7 +16,7 @@ type my_list 'x = Cons ('x, my_list 'x) | Nil
 
 type opt 'a = None | Some 'a
 
-len l = match l with
+let len l = match l with
     Nil -> 0
     -- single line comment should be ignored:
   | Cons (_, tail) -> 1 + (len tail)

--- a/test_files/use_radius.alp
+++ b/test_files/use_radius.alp
@@ -2,4 +2,4 @@ module use_radius
 
 export test_radius/1
 
-test_radius () = (radius.radius_to_int (radius.make_radius 1)) 
+let test_radius () = (radius.radius_to_int (radius.make_radius 1)) 

--- a/test_files/values.alp
+++ b/test_files/values.alp
@@ -4,27 +4,17 @@ export test_values/1
 
 type simple_adt = AnInt int | AString string
 
-test_int = 41
- 
-test_string = "Vicugna pacos"
-
-test_float = 0.5
-
-test_record = {x = 19}
-
-test_binary = <<1: size=8, 2: size=8>>
-
-test_array = [1, 2, 3, 4]
-
-test_adt = AnInt 5
-
-test_atom = :nope
-
-test_bool = true
-
-test_chars = c"x"
-
-test_tuple = (100, "100")
+let test_int = 41 
+let test_string = "Vicugna pacos"
+let test_float = 0.5
+let test_record = {x = 19}
+let test_binary = <<1: size=8, 2: size=8>>
+let test_array = [1, 2, 3, 4]
+let test_adt = AnInt 5
+let test_atom = :nope
+let test_bool = true
+let test_chars = c"x"
+let test_tuple = (100, "100")
 
 -- Note the use of the value of test_int in an expression
-test_values () = (test_int + 1, test_string)
+let test_values () = (test_int + 1, test_string)


### PR DESCRIPTION
This PR represents a small shift in how we lex/parse statements at the top level.

Previously, all top level statements had to terminate with at least two new lines, i.e. `\n\n`. This meant encountering situations such as this: #82 

To remedy this, and following discussions with @j14159 and @ypaq on IRC, this proposed PR includes the following changes:

1. All whitespace significance is removed.
2. After the initial scanning, breaks are inserted into the token list by logically determining top level keywords. This has to be done with some notion of state in this style as 'type' and 'let' may have a different meaning depending on their context. This step can be found [here](https://github.com/alpaca-lang/alpaca/compare/master...lepoetemaudit:top-level-let-ignore-ws?expand=1#diff-5a99f1ea2b47a1485d1c6a88d20a180aR17).
3.  We now require 'let' before top level function / value definitions. It's noisier than before, but there isn't any way of otherwise distinguishing these from other top level constructs, so it was this or add more whitespace significance and 'offside' rules such as in Haskell/Elm. On the bright side, more OCaml code just became copy-pastable into Alpaca :)
4. The previous fix to sanitise groups of newlines is no longer required so it has been removed

I also made it aware of the up-coming 'import' keyword so hopefully integrating that will be smooth.