### PR TITLE
Add more property tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: erlang
 otp_release:
   - 19.1
-  - 18.3
-  - 18.2
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Alpaca is a statically typed, strict/eagerly evaluated, functional programming l
 # TLDR; How Do I Use It?
 Make sure the following are installed:
 
-- Erlang OTP 18.2 or above ([packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html), most development at present uses OTP 19.1 locally from [kerl](https://github.com/kerl/kerl))
+- Erlang OTP 19.1 or above ([packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html), most development at present uses OTP 19.1 locally from [kerl](https://github.com/kerl/kerl))
 - [Rebar3](https://rebar3.org)
 
 Make a new project with `rebar3 new app your_app_name` and in the
@@ -129,7 +129,7 @@ tests in `alpaca_typer.erl`.
 ## Prerequisites
 You will generally want the following two things installed:
 
-- Erlang/OTP 18.2 or above ([packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html), most development so far uses OTP 19.1 locally from [kerl](https://github.com/kerl/kerl))
+- Erlang/OTP 19.1 or above ([packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html), most development so far uses OTP 19.1 locally from [kerl](https://github.com/kerl/kerl))
 - [Rebar3](https://rebar3.org)
 
 ## Writing Alpaca with Rebar3
@@ -473,7 +473,7 @@ the code, including but not limited to:
   expression rather than in the clauses.  I'm considering tracking the
   history of changes over the course of unifications in a reference
   cell in order to provide a typing trace to the user.
-- generalization of type variables is incompletely applied. 
+- generalization of type variables is incompletely applied.
 
 # Parsing Approach
 Parsing/validating occurs in several passes:

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -9,34 +9,220 @@
 all() -> [proper_compile].
 
 proper_compile(_Config) ->
-    ?assert(proper:quickcheck(prop_can_compile_module_def(), [{numtests, 1000}])).
+    NumTests = list_to_integer(os:getenv("NUMTESTS", "1000")),
+    ?assert(proper:quickcheck(prop_can_compile_module_def(), [{numtests, NumTests}])),
+    ?assert(proper:quickcheck(prop_can_compile_type_decl(), [{numtests, NumTests},
+                                                             {max_size, 10}
+                                                            ])).
 
 prop_can_compile_module_def() ->
-    ?FORALL(Module, g_module(), can_compile(Module)).
+    ?FORALL(ModuleDef, g_module_def(), can_compile(ModuleDef)).
+
+g_module_def() ->
+    ?LET(Module, g_module(), to_binary([Module], [])).
+
+prop_can_compile_type_decl() ->
+    ?FORALL(Code, g_module_with_type_declaration(), can_compile(Code)).
+
+g_module_with_type_declaration() ->
+    ?LET({Module,
+          TypeDecl},
+         {g_module(),
+          g_type_declaration([])},
+         ?LET(MoreTypeDecl, g_type_declaration([TypeDecl]),
+              to_binary([Module, TypeDecl, MoreTypeDecl], []))).
 
 can_compile(Code) ->
     ?WHENFAIL(ct:pal("failed to compile:~n~p~n", [Code]),
-              case alpaca:compile({text, [Code]}) of
-                  {ok, _, _} -> true;
-                  {ok, _, _, _} -> true;
-                  {error, _} -> false
-              end).
+              ?TIMEOUT(timer:seconds(5),
+                       case alpaca:compile({text, [Code]}) of
+                           {ok, _, _} -> true;
+                           {ok, _, _, _} -> true;
+                           {error, _} -> false
+                       end)).
+
 
 %%% Module generators
 
 %% @doc Generate module declaration.
 g_module() ->
-    ?LET(Mod, g_module_name(),
-         ?LET(Tokens, g_sprinkle_whitespace(["module", Mod, $\n]),
-              ?LET(ModuleDef, g_sprinkle_comments(Tokens),
-                   list_to_binary(ModuleDef)))).
+    ?LET(Mod, g_module_name(), {module, Mod}).
 
 %% @doc Generate a module name.
 %% Module names are turned into atoms. The module name is internally prefixed
 %% with 'alpaca_'. Atom max length is 255.
 %% @end
 g_module_name() ->
-    ?LET(N, integer(1, 248), ?LET(Module, g_sym(N), Module)).
+    ?LET(N, integer(1, 248),
+         ?LET(Module,
+              ?SUCHTHAT(Name, g_sym(N), not lists:member(Name, keywords())),
+              Module)).
+
+
+%%% Type generators
+
+g_type_declaration(KnownTypes) ->
+    ?LET({Name, Params}, {g_type_name(KnownTypes), list(g_type_param())},
+         ?LET(Type, ?SUCHTHAT(T, g_type_top_level_def(Name, Params, KnownTypes),
+                              is_valid_type(T, KnownTypes)),
+              {type, Name, Params, Type})).
+
+is_valid_type(Type, KnownTypes) ->
+    Constructors = lists:flatten(extract_constructors(Type) ++
+                                 [extract_constructors(T) || T <- KnownTypes]),
+    %% unique constructors
+    Constructors -- lists:usort(Constructors) == [].
+
+g_type_name(KnownTypes) ->
+    ?LET(TypeName,
+         ?SUCHTHAT(Name, g_sym(), is_valid_type_name(Name, KnownTypes)),
+         TypeName).
+
+is_valid_type_name(Name, KnownTypes) ->
+    %% unique type name
+    not lists:member(Name, [extract_type_name(T) || T <- KnownTypes])
+    andalso
+    %% name is not a keyword
+    not lists:member(Name, keywords()).
+
+g_type_param() ->
+    ?LET(Param, g_sym(), list_to_binary([$', Param])).
+
+g_type_top_level_def(Name, Params, KnownTypes) ->
+    ?SIZED(Size, g_type_top_level_def(Name, Params, KnownTypes, Size)).
+g_type_top_level_def(Name, Params, KnownTypes, 0) ->
+    oneof([g_type_constructor_name(),
+           g_type_def(Name, Params, KnownTypes),
+           g_type_construct(g_type_def(Name, Params, KnownTypes))]);
+g_type_top_level_def(Name, Params, KnownTypes, Size) ->
+    oneof([g_type_top_level_def(Name, Params, KnownTypes, 0),
+           ?LAZY(g_type_union(Name, Params, KnownTypes, Size))
+          ]).
+
+g_type_construct(Of) ->
+    ?LET(Constructor, g_type_constructor_name(),
+         {construct, Constructor, Of}).
+
+g_type_constructor_name() ->
+    ?LET(N, non_neg_integer(),
+         ?LET({U, Rest},
+              {g_u(), vector(N, oneof([g_d(), g_l(), g_u(), $_]))},
+              {constructor, list_to_binary([U, Rest])})).
+
+g_type_union(Name, Params, KnownTypes, 1) ->
+    g_type_top_level_def(Name, Params, KnownTypes, 0);
+g_type_union(Name, Params, KnownTypes, Size) ->
+    ?LET(OfTypes, vector(Size, g_type_top_level_def(Name, Params, KnownTypes, 0)),
+         {union, OfTypes}).
+
+g_type_def(Name, Params, KnownTypes) ->
+    ?SIZED(Size, g_type_def(Name, Params, KnownTypes, Size)).
+
+g_type_def(Name, Params, KnownTypes, 0) ->
+    oneof([g_base_type(),
+           Name
+          ]
+          ++ [oneof(Params) || length(Params) > 0]
+          ++ [oneof([extract_type_name(KnownType) || KnownType <- KnownTypes])
+              || length(KnownTypes) > 0]
+         );
+g_type_def(Name, Params, KnownTypes, Size) ->
+    oneof([g_type_def(Name, Params, KnownTypes, 0),
+           ?LAZY(g_type_list(g_type_def(Name, Params, KnownTypes, Size div 2))),
+           ?LAZY(g_type_map(g_type_def(Name, Params, KnownTypes, Size div 2),
+                            g_type_def(Name, Params, KnownTypes, Size div 2))),
+           ?LAZY(g_type_pid(g_type_def(Name, Params, KnownTypes, Size div 2))),
+           ?LAZY(g_type_tuple(Name, Params, KnownTypes, Size div 2))
+          ]).
+
+g_base_type() ->
+    oneof(base_types()).
+
+g_type_list(Of) ->
+    {list, Of}.
+
+g_type_map(KeyType, ValueType) ->
+    {map, KeyType, ValueType}.
+
+g_type_pid(Of) ->
+    {pid, Of}.
+
+g_type_tuple(Name, Params, KnownTypes, N) when N =< 1->
+    g_type_def(Name, Params, KnownTypes, 0);
+g_type_tuple(Name, Params, KnownTypes, Size) ->
+    ?LET(OfTypes,
+         vector(Size, g_type_def(Name, Params, KnownTypes, Size div 2)),
+         {tuple, OfTypes}).
+
+to_binary([], Acc) ->
+    g_sprinkle(lists:flatten(lists:reverse(Acc)));
+to_binary([{module, Mod} | Rest], Acc) ->
+    to_binary(Rest, [[<<"module">> , Mod, g_breaks()]| Acc]);
+to_binary([{type, Name, Params, Type} | Rest], Acc) ->
+    to_binary(Rest,
+              [[<<"type">>, Name, Params, $=, to_binary(Type), g_breaks()] | Acc]).
+
+to_binary({construct, Constructor, Of}) ->
+    [to_binary(Constructor), to_binary(Of)];
+to_binary({union, OfTypes}) ->
+    lists:join($|, [to_binary(Type) || Type <- OfTypes]);
+to_binary({list, Of}) ->
+    [<<"list">>, to_binary(Of)];
+to_binary({map, KeyType, ValueType}) ->
+    [<<"map">>, $(, to_binary(KeyType), $), to_binary(ValueType)];
+to_binary({pid, Of}) ->
+    [<<"pid">>, to_binary(Of)];
+to_binary({tuple, OfTypes}) ->
+    [$(, lists:join($,, [to_binary(Type) || Type <- OfTypes]), $)];
+to_binary({constructor, Constructor}) ->
+    Constructor;
+to_binary(Binary) when is_binary(Binary) ->
+    Binary.
+
+
+%%% Function generators
+
+g_function() ->
+    ?LET({F, Body},
+         {g_function_name(), g_function_body()},
+         g_sprinkle_whitespace(["let", F, "()", "=", Body, $\n])).
+
+g_function_name() ->
+    ?LET(Fun, g_sym(), Fun).
+
+g_function_body() ->
+    g_basic_value().
+
+
+%%% Value generators
+
+%% Basic values
+
+g_basic_value() ->
+    oneof(base_types()).
+
+g_boolean() ->
+    oneof(["true", "false"]).
+
+g_number() ->
+    oneof([g_d(), g_float()]).
+
+g_float() ->
+    ?LET({D, R}, {g_d(), g_d()}, list_to_binary([D, ".", R])).
+
+g_atom() ->
+    ?LET(N, integer(1, 255),
+         ?LET(Atom, vector(N, oneof([g_l(), g_u(), g_d(), $*, $_])),
+              list_to_binary([$:, Atom]))).
+
+g_string() ->
+    ?LET(String, string(), list_to_binary([$", String, $"])).
+
+g_char_list() ->
+    ?LET(String, string(), list_to_binary([$c, $", String, $"])).
+
+g_binary() ->
+    binary().
 
 
 %%% Comments generators
@@ -53,43 +239,50 @@ g_comment() ->
 
 g_line_comment() ->
     ?LET(Comment, ?SUCHTHAT(Str, string(), not lists:member($\n, Str)),
-         ["--", unicode:characters_to_binary(Comment), $\n]).
+         [<<"--">>, unicode:characters_to_binary(Comment), $\n]).
 
 g_block_comment() ->
     ?LET(Comment,
          ?SUCHTHAT(Str, string(),
                    nomatch == re:run(unicode:characters_to_binary(Str), "({-|-})",
                                      [{capture, none}])),
-         ["{-", unicode:characters_to_binary(Comment), "-}"]).
+         [<<"{-">>, unicode:characters_to_binary(Comment), <<"-}">>]).
 
-%%% Type generators
 
-g_type_declaration() ->
-    ?LET(N, pos_integer(),
-         ?LET({Name, Type}, {g_type_name(N), g_type()},
-              ["type", Name, "=", Type, $\n])).
+%%% Whitespace generators
 
-g_type_name(N) ->
-    ?LET({U, Rest},
-         {g_u(), vector(N - 1, oneof([g_d(), g_l(), g_u(), $_]))},
-         list_to_binary([U, Rest])).
+g_sprinkle_whitespace(Tokens) ->
+    ?LET({Begin,
+          Spaces,
+          End,
+          Newlines},
+         {list(oneof([g_space(), g_tab()])),
+          vector(length(Tokens) - 1, g_whitespace()),
+          list(oneof([g_space(), g_tab()])),
+          list(g_newline())},
+         begin
+             Line = lists:zipwith(fun(Token, Space) -> [Token, Space] end,
+                                  Tokens, Spaces ++ [""]),
+             [Begin, Line, End, Newlines]
+         end).
 
-g_type() ->
-    "".
+%% @doc Generate at least one whitespace.
+g_whitespace() ->
+    non_empty(oneof([g_space(), g_tab(), $\f, $\v, $\n])).
 
-%%% Function generators
+g_tab() -> $\t.
 
-g_function() ->
-    ?LET({F, Body},
-         {g_function_name(), g_function_body()},
-         g_sprinkle_whitespace(["let", F, "()", "=", Body, $\n])).
+g_space() -> " ".
 
-g_function_name() ->
-    ?LET(N, pos_integer(), ?LET(Fun, g_sym(N), Fun)).
+g_newline() ->
+    oneof([$\n, <<"\r\n">>]).
 
-g_function_body() ->
-    g_basic_value().
+g_breaks() ->
+    non_empty(oneof([g_break(), g_newline()])).
 
+g_break() -> <<";;">>.
+
+%%% Helpers.
 
 %% @doc Generate lower case letter.
 g_l() ->
@@ -103,71 +296,64 @@ g_u() ->
 g_d() ->
     integer($0, $9).
 
+g_sym() ->
+    ?LET(N, pos_integer(), g_sym(N)).
+
 g_sym(N) ->
     ?LET({L, Rest},
          {g_l(), vector(N - 1, oneof([g_d(), g_l(), g_u(), $_]))},
          list_to_binary([L, Rest])).
 
+%% @doc Generate whitespace and comments and add them into an iolist of tokens.
+g_sprinkle(Tokens) ->
+    ?LET(SpacedTokens, g_sprinkle_whitespace(Tokens),
+         ?LET(CommentedTokens, g_sprinkle_comments(SpacedTokens),
+              list_to_binary(CommentedTokens))).
 
-%%% Value generators
+%%% Extraction functions
 
-%% Basic values
+extract_constructors({constructor, Constructor}) ->
+    [Constructor];
+extract_constructors({construct, Constructor, _}) ->
+    extract_constructors(Constructor);
+extract_constructors({union, OfTypes}) ->
+    [extract_constructors(Type) || Type <- OfTypes];
+extract_constructors({type, _, _, Type}) ->
+    lists:flatten(extract_constructors(Type));
+extract_constructors(_) ->
+    [].
 
-g_basic_value() ->
-    oneof([g_boolean(), g_number(), g_atom(), g_string(), g_char_list(),
-           g_binary()]).
+extract_type_name({type, Name, _, _}) -> Name.
 
-g_boolean() ->
-    oneof(["true", "false"]).
+keywords() ->
+    [<<"let">>,
+     <<"in">>,
+     <<"match">>,
+     <<"with">>,
+     <<"beam">>,
+     <<"module">>,
+     <<"export">>,
+     <<"type">>,
+     <<"export_type">>,
+     <<"import_type">>,
+     <<"spawn">>,
+     <<"send">>,
+     <<"receive">>,
+     <<"after">>,
+     <<"test">>,
+     <<"error">>,
+     <<"exit">>,
+     <<"throw">>,
+     <<"true">>,
+     <<"false">>
+    ]
+    ++ base_types().
 
-g_number() ->
-    oneof([g_d(), g_float()]).
-
-g_float() ->
-    ?LET({D, R}, {g_d(), g_d()}, list_to_binary([D, ".", R])).
-
-g_atom() ->
-    ?LET(N, integer(1, 255),
-         ?LET(Atom, vector(N, oneof([g_l(), g_u(), g_d(), $*, $_])),
-              list_to_binary([":", Atom]))).
-
-g_string() ->
-    ?LET(String, string(), list_to_binary(["\"", String, "\""])).
-
-g_char_list() ->
-    ?LET(String, string(), list_to_binary(["c", "\"", String, "\""])).
-
-g_binary() ->
-    binary().
-
-
-%%% Whitespace generators
-
-g_sprinkle_whitespace(Tokens) ->
-    ?LET({Begin,
-          Spaces,
-          End,
-          Breaks},
-         {list(oneof([g_space(), g_tab()])),
-          vector(length(Tokens) - 1, g_line_space()),
-          list(oneof([g_space(), g_tab()])),
-          g_breaks()},
-         begin
-             Line = lists:zipwith(fun(Token, Space) -> [Token, Space] end,
-                                  Tokens, Spaces ++ [""]),
-             [Begin, Line, End, Breaks]
-         end).
-
-%% @doc Generate at least one whitespace on the same line.
-g_line_space() ->
-    non_empty(oneof([g_space(), g_tab(), $\f, $\v])).
-
-g_tab() -> "\t".
-
-g_space() -> " ".
-
-g_breaks() ->
-    ?LET(N, pos_integer(), ?LET(Breaks, vector(N, g_newline()), Breaks)).
-
-g_newline() ->
-    oneof(["\n", "\r\n"]).
+base_types() ->
+    [<<"atom">>,
+     <<"int">>,
+     <<"float">>,
+     <<"string">>,
+     <<"bool">>,
+     <<"binary">>
+    ].

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -15,13 +15,12 @@ prop_can_compile_module_def() ->
     ?FORALL(Module, g_module(), can_compile(Module)).
 
 can_compile(Code) ->
-    case alpaca:compile({text, [Code]}) of
-        {ok, _, _} -> true;
-        {ok, _, _, _} -> true;
-        {error, _} ->
-            ct:fail("failed to compile:~n~p~n", [Code]),
-            false
-    end.
+    ?WHENFAIL(ct:pal("failed to compile:~n~p~n", [Code]),
+              case alpaca:compile({text, [Code]}) of
+                  {ok, _, _} -> true;
+                  {ok, _, _, _} -> true;
+                  {error, _} -> false
+              end).
 
 %%% Module generators
 


### PR DESCRIPTION
Property tests now generate two type declarations, the second one may use the name of the first. 

You can now adjust the number of tests with `NUMTESTS=10000 rebar3 ct`. The default is 1000 test cases.