### PR TITLE
Scanner fixes

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -22,7 +22,8 @@ parse_module(NextVarNum, Text) when is_list(Text) ->
     {ok, Tokens, _} = alpaca_scanner:scan(Text),
     rebind_and_validate_module(NextVarNum,
                                parse_module(Tokens, #alpaca_module{}));
-
+parse_module(NextVarNum, Text) when is_binary(Text) ->
+    parse_module(NextVarNum, binary:bin_to_list(Text));
 parse_module([], #alpaca_module{name=no_module}) ->
     {error, no_module_defined};
 parse_module([], #alpaca_module{name=N, functions=Funs, types=Ts}=M) ->

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -161,7 +161,7 @@ _    : {token, {'_', TokenLine}}.
 {-([^-]|(-+[^-}]))*-+} :
   validate_comment(TokenLine, string:sub_string(TokenChars, 3, length(TokenChars)-2)).
 
-
+. : {error, "Unexpected token: " ++ TokenChars}.
 
 Erlang code.
 

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -7,14 +7,13 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-scan(Code) ->    
-    %% Scan and infer break tokens if not provided
-    {ok, Re} = re:compile("\n([ \t]+)\n", [unicode]),
-    Sanitized = re:replace(Code, Re, "\n\n", [{return,list},global]),
-    case alpaca_scan:string(Sanitized) of
+scan(Code) when is_list(Code) -> 
+    case alpaca_scan:string(Code) of
         {ok, Tokens, Num} -> {ok, infer_breaks(Tokens), Num};    
         Error -> Error
-    end.
+    end;
+scan(Code) when is_binary(Code) ->
+    scan(binary:bin_to_list(Code)).
 
 infer_breaks(Tokens) ->
     %% Reduce tokens from the right, inserting a break (i.e. ';;') before

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -137,4 +137,12 @@ infer_bin_test() ->
                      ],                       
     ?assertEqual({ok, ExpectedTokens, 2}, scan(Code)).
 
+unexpected_token_test_() ->
+    [?_assertMatch(
+        {error, {1,alpaca_scan,{user, "Unexpected token: ;"}}, 1},
+        scan("module bin ; hello")),
+     ?_assertMatch(
+        {error, {1,alpaca_scan,{user, "Unexpected token: '"}}, 1},
+        scan("module bin ' hello"))].
+
 -endif.

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -35,7 +35,7 @@ g_module_with_type_declaration() ->
 can_compile(Code) ->
     ?WHENFAIL(ct:pal("failed to compile:~n~p~n", [Code]),
               ?TIMEOUT(timer:seconds(5),
-                       case alpaca:compile({text, [Code]}) of
+                       case alpaca:compile({text, Code}) of
                            {ok, _, _} -> true;
                            {ok, _, _, _} -> true;
                            {error, _} -> false


### PR DESCRIPTION
This removes the sanitisation regex before scanning but implements its side-effect: coercing all input to lists, as Leex appears to choke otherwise. Also, Leex was hanging on unknown tokens such as apostrophe. I added a catch-all which fixes this.