### PR TITLE
Cleanup many unused or shadowed variables

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -341,8 +341,7 @@ next_batch([Token|Tail], Memo) ->
         TopLevel::alpaca_fun_def()) -> {integer(), map(), alpaca_fun_def()} |
                                      {error, term()}.
 rename_bindings(Environment, #alpaca_fun_def{}=TopLevel) ->
-    #alpaca_fun_def{name={symbol, _, Name}, versions=Vs}=TopLevel,
-    _SeedMap = #{Name => Name},
+    #alpaca_fun_def{name={symbol, _, _}, versions=Vs}=TopLevel,
 
     F = fun(#alpaca_fun_version{args=As, body=Body}=FV, {Env, Map, Versions}) ->
                 case make_bindings(Env, Map, As) of

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -140,7 +140,7 @@ expand_imports([M|Tail], ExportMap, Memo) ->
     expand_imports(Tail, ExportMap, [M2|Memo]).
 
 %% Group all functions by name and arity:
-group_funs(Funs, ModuleName) ->
+group_funs(Funs, _ModuleName) ->
     OrderedKeys = 
         drop_dupes_preserve_order(
           lists:map(
@@ -195,7 +195,7 @@ rebind_and_validate_module(NextVarNum, #alpaca_module{}=Mod, Modules) ->
 %% All available modules required so that we can rewrite applications of
 %% functions not in Mod to inter-module calls.
 rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
-    #alpaca_module{name=MN, functions=Funs}=Mod,
+    #alpaca_module{name=_MN, functions=Funs}=Mod,
     Bindings = [{N, A} || #alpaca_fun_def{name={_, _, N}, arity=A} <- Funs],
     Env = #env{next_var=NextVarNum,
                rename_map=maps:new(),
@@ -206,7 +206,7 @@ rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
     F = fun(_, {error, _}=Err) ->
                 Err;
            (F, {E, Memo}) ->
-                {#env{next_var=NV2, rename_map=M}, M2, F2} = rename_bindings(E, F),
+                {#env{next_var=NV2, rename_map=_M}, M2, F2} = rename_bindings(E, F),
                     
                 %% We invert the returned map so that it is from
                 %% synthetic variable name to source code variable
@@ -218,7 +218,7 @@ rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
     case lists:foldl(F, {Env, []}, Funs) of
         {error, _}=Err ->
             Err;
-        {#env{next_var=NV2, rename_map=M}, Funs2} ->
+        {#env{next_var=NV2, rename_map=_M}, Funs2} ->
             %% TODO:  other parts of the compiler might care about the rename
             %%        map but we do throw away some details deliberately
             %%        when rewriting patterns and different function versions.
@@ -342,13 +342,13 @@ next_batch([Token|Tail], Memo) ->
                                      {error, term()}.
 rename_bindings(Environment, #alpaca_fun_def{}=TopLevel) ->
     #alpaca_fun_def{name={symbol, _, Name}, versions=Vs}=TopLevel,
-    SeedMap = #{Name => Name},
+    _SeedMap = #{Name => Name},
 
     F = fun(#alpaca_fun_version{args=As, body=Body}=FV, {Env, Map, Versions}) ->
                 case make_bindings(Env, Map, As) of
                     {Env2, M2, Args} ->
                         case rename_bindings(Env2, M2, Body) of
-                            {Env3, M3, E} ->
+                            {Env3, _M3, E} ->
                                 FV2 = FV#alpaca_fun_version{
                                         args=Args,
                                         body=E},
@@ -423,7 +423,7 @@ rename_bindings(Environment, M, #alpaca_fun_def{name={symbol, L, Name}}=Def) ->
                         case rename_bindings(Env2, M3, Body) of
                             {error, _}=Err -> 
                                 throw(Err);
-                            {Env3, M4, Body2} ->
+                            {Env3, _M4, Body2} ->
                                 FV2 = FV#alpaca_fun_version{
                                         args=Args2,
                                         body=Body2},
@@ -478,7 +478,7 @@ rename_bindings(Env, Map, #alpaca_apply{expr=N, args=Args}=App) ->
     ImpFuns = fun () ->
                       Mod = Env#env.current_module,
                       #alpaca_module{function_imports=Imps} = Mod,
-                      [{{X, A}, Mod} || {X, {Mod, A}} <- Imps]
+                      [{{X, A}, Mod1} || {X, {Mod1, A}} <- Imps]
               end,
 
     FName = case N of

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -41,7 +41,7 @@
           synthetic_fun_num=0 :: integer()
          }).
 
-make_env(#alpaca_module{functions=Funs}=Mod) ->
+make_env(#alpaca_module{functions=Funs}=_Mod) ->
     TopLevelFuns = [{N, A} || #alpaca_fun_def{name={symbol, _, N}, arity=A} <- Funs],
     #env{module_funs=TopLevelFuns, wildcard_num=0}.
 
@@ -140,7 +140,7 @@ gen_fun_patterns(Env, #alpaca_fun_def{name={symbol, _, N}, arity=A, versions=Vs}
     %% Nest matches:
     FName = cerl:c_fname(list_to_atom(N), A),
     Args = [cerl:c_var(list_to_atom(X)) || X <- VarNames],
-    [TopVar|_] = VarNames,
+    [_TopVar|_] = VarNames,
     B = cerl:c_case(
           cerl:c_values(Args),
           [gen_fun_version(Env, Version) || Version <- Vs]),
@@ -468,7 +468,7 @@ gen_bits(Env,
 
 gen_bits(Env, [Bits|Rem], Memo) ->
     #alpaca_bits{value=V, size=S, unit=U, type=T, sign=Sign, endian=E} = Bits,
-    {Env2, VExp} = gen_expr(Env, V),
+    {_Env2, VExp} = gen_expr(Env, V),
     B = cerl:c_bitstr(VExp, cerl:c_int(S), cerl:c_int(U),
                       get_bits_type(T), bits_flags(Sign, E)),
     gen_bits(Env, Rem, [B|Memo]).

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -135,7 +135,7 @@ poly_type -> symbol type_expressions :
   #alpaca_type{name={type_name, L, N}, members=Members, vars=Vars}.
 
 record_type_member -> symbol ':' type_expr : 
-  {symbol, L, N} = '$1',
+  {symbol, _L, N} = '$1',
   #t_record_member{name=list_to_atom(N), type='$3'}.
 
 record_type_members -> record_type_member : ['$1'].

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -27,7 +27,7 @@ infer_breaks(Tokens) ->
     Reducer = fun(Token, {LetLevel, InBinary, Acc}) ->                     
         {Symbol, Line} = case Token of
             {S, L} when is_integer(L) -> {S, L};
-            Other -> {other, 0}
+            _Other -> {other, 0}
         end,
         InferBreak = fun() -> 
             {0, InBinary, [{break, Line} | [ Token | Acc]]} 

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -697,7 +697,7 @@ unify_adt_and_poly(C1, C2, #adt{members=Ms}=A, ToCheck, Env, L) when is_pid(ToCh
 %% ToCheck needs to be in a reference cell for unification and we're not 
 %% worried about losing the cell at this level since C1 and C2 are what
 %% will actually be manipulated.
-unify_adt_and_poly(C1, C2, #adt{members=Ms}=A, ToCheck, Env, L) ->
+unify_adt_and_poly(C1, C2, #adt{members=_Ms}=A, ToCheck, Env, L) ->
     unify_adt_and_poly(C1, C2, A, new_cell(ToCheck), Env, L).
 
 %%% Given two different types, find a type in the set of currently available
@@ -797,7 +797,7 @@ unify_records(LowerBound, Target, Env, Line) ->
             unify(LowerRow, NewTarget, Env, Line)
     end.
 
-unify_record_members([], TargetRem, Env, Line) ->
+unify_record_members([], TargetRem, _Env, _Line) ->
     lists:map(fun({_, X}) -> X end, TargetRem);
 unify_record_members([LowerBound|Rem], TargetRem, Env, Line) ->
     #t_record_member{name=N, type=T} = LowerBound,
@@ -832,7 +832,7 @@ flatten_record(#t_record{members=Ms, row_var=#t_record{}=Inner}) ->
 flatten_record(#t_record{row_var=P}=R) when is_pid(P) ->
     case get_cell(P) of
         #t_record{}=Inner -> flatten_record(R#t_record{row_var=Inner});
-        {link, L}=Link    -> flatten_record(R#t_record{row_var=L});
+        {link, L}=_Link   -> flatten_record(R#t_record{row_var=L});
         _                 -> R
     end;
 flatten_record(#t_record{}=R) ->
@@ -907,7 +907,7 @@ inst_type_members(ADT, [#t_record{}=R|Rem], Env, Memo) ->
                       _ ->
                           {RV, Env}
                   end,
-    F = fun(#t_record_member{type=T}=M, {NewMems, E}) ->
+    F = fun(#t_record_member{type=T}=M, {NewMems, _E}) ->
                 case inst_type_members(ADT, [T], Env, []) of
                     {error, _}=Err -> 
                         erlang:error(Err);
@@ -1143,7 +1143,7 @@ inst({t_arrow, Params, ResTyp}, Lvl, Env, CachedMap) ->
     {_, NewEnv, M, PTs} = lists:foldr(Folder, {Lvl, Env, CachedMap, []}, Params),
     {RT, NewEnv2, M2} = inst(ResTyp, Lvl, NewEnv, M),
     {{t_arrow, PTs, RT}, NewEnv2, M2};
-inst({t_receiver, Recv, Body}=R, Lvl, Env, CachedMap) ->
+inst({t_receiver, Recv, Body}=_R, Lvl, Env, CachedMap) ->
     {Body2, Env2, Map2} = inst(Body, Lvl, Env, CachedMap),
     {Recv2, Env3, Map3} = inst(Recv, Lvl, Env2, Map2),
     NewR = {t_receiver, Recv2, Body2},
@@ -1364,7 +1364,7 @@ typ_of(Env, Lvl, {symbol, _, N}) ->
         {error, _} = E -> E;
         {T, #env{next_var=VarNum}, _} -> {T, VarNum}
     end;
-typ_of(Env, Lvl, #alpaca_far_ref{module=Mod, name=N, line=L, arity=A}) ->
+typ_of(Env, _Lvl, #alpaca_far_ref{module=Mod, name=N, line=_L, arity=A}) ->
     EnteredModules = [Mod | Env#env.entered_modules],
     {ok, Module, _} = extract_module_bindings(Env, Mod, N),
 
@@ -1501,13 +1501,13 @@ typ_of(Env, Lvl, #alpaca_map_add{line=L, to_add=A, existing=B}) ->
 
 %% Record typing:
 typ_of(Env, Lvl, #alpaca_record{members=Members}) ->
-    F = fun(#alpaca_record_member{name=N, val=V}, {Members, E}) ->
+    F = fun(#alpaca_record_member{name=N, val=V}, {ARMembers, E}) ->
                 case typ_of(E, Lvl, V) of
                     {error, _}=Err -> 
                         erlang:error(Err);
                     {VTyp, NextVar} ->
                         MTyp = #t_record_member{name=N, type=VTyp},
-                        {[MTyp|Members], update_counter(NextVar, E)}
+                        {[MTyp|ARMembers], update_counter(NextVar, E)}
                 end
         end,
     {Members2, Env2} = lists:foldl(F, {[], Env}, Members),
@@ -1597,7 +1597,7 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
     ForwardFun =
         fun() ->
                 FN = case Expr of
-                         {symbol, Line, FunName}    -> FunName;
+                         {symbol, _Line, FunName}    -> FunName;
                          {bif, FunName, _, _, _} -> FunName
                      end,
                 Mod = Env#env.current_module,
@@ -1747,7 +1747,7 @@ typ_of(#env{next_var=NV}=Env, Lvl, #alpaca_ffi{clauses=Cs, module={_, L, _}}) ->
     end;
 
 %% Spawning of functions in the current module:
-typ_of(Env, Lvl, #alpaca_spawn{line=L, module=undefined, function=F, args=Args}) ->
+typ_of(Env, Lvl, #alpaca_spawn{line=_L, module=undefined, function=F, args=Args}) ->
     %% make a function application and type it:
     Apply = #alpaca_apply{line=0, expr=F, args=Args},
 
@@ -1805,10 +1805,9 @@ typ_of(EnvIn, Lvl, #alpaca_fun_def{name={symbol, L, N}, versions=Vs}) ->
                                 %% checking we're only interested in their 
                                 %% return value
                                 case JustTypes of
-                                    [] -> [N, unwrap(T)], {[T|Types],
-                                          update_counter(NextVar, Env2)};
-                                    _ -> {[{t_arrow, JustTypes, T}|Types],
-                                         update_counter(NextVar, Env2)}
+                                    [] -> {[T|Types], update_counter(NextVar, Env2)};
+                                    _  -> {[{t_arrow, JustTypes, T}|Types],
+                                          update_counter(NextVar, Env2)}
                                 end                         
                         end
                 end
@@ -2054,7 +2053,7 @@ typ_apply(Env, Lvl, TypF, NextVar, Args, Line) ->
                     {error, _}=Err -> Err;
                     {Typ, NV} ->
                         case get_cell(Typ) of
-                            {t_receiver, Recv2, RetTyp} ->
+                            {t_receiver, _Recv2, RetTyp} ->
                                 case unify(R2, Recv, Env, Line) of
                                     {error, _}=Err -> Err;
                                     ok ->
@@ -2128,7 +2127,7 @@ extract_module_bindings(Env, ModuleName, BindingName) ->
             {error, {no_module, ModuleName}};
         [Module] ->
             Exports = Module#alpaca_module.function_exports,
-            case [F || {N, A} = F <- Exports, N =:= BindingName] of
+            case [F || {N, _A} = F <- Exports, N =:= BindingName] of
                 []  ->
                     throw({error, {not_exported, ModuleName, BindingName}});
                 Funs ->
@@ -2233,7 +2232,7 @@ add_bindings(#alpaca_binary{}=Bin, Env, Lvl, NameNum) ->
     end;
 
 add_bindings(#alpaca_map{}=M, Env, Lvl, NN) ->
-    {M2, NN2} = rename_wildcards(M, NN),
+    {M2, _NN2} = rename_wildcards(M, NN),
     Folder = fun(_, {error, _}=Err) -> Err;
                 (#alpaca_map_pair{key=K, val=V}, {E, N}) ->
                      case add_bindings(K, E, Lvl, N) of
@@ -2255,8 +2254,8 @@ add_bindings(#alpaca_map{}=M, Env, Lvl, NN) ->
     end;
 
 add_bindings(#alpaca_record{}=R, Env, Lvl, NameNum) ->
-    {R2, NameNum2} = rename_wildcards(R, NameNum),
-    F = fun(#alpaca_record_member{val=V}=M, {E, N}) ->
+    {R2, _NameNum2} = rename_wildcards(R, NameNum),
+    F = fun(#alpaca_record_member{val=V}=_M, {E, N}) ->
                 case add_bindings(V, E, Lvl, N) of
                     {error, _}=Err  -> erlang:error(Err);
                     {_, _, E2, N2} -> {E2, N2}

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1,4 +1,4 @@
-%%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %%% ex: ft=erlang ts=4 sw=4 et
 %%%
 %%% Copyright 2016 Jeremy Pierre
@@ -2053,7 +2053,7 @@ typ_apply(Env, Lvl, TypF, NextVar, Args, Line) ->
                     {error, _}=Err -> Err;
                     {Typ, NV} ->
                         case get_cell(Typ) of
-                            {t_receiver, _Recv2, RetTyp} ->
+                            {t_receiver, _, RetTyp} ->
                                 case unify(R2, Recv, Env, Line) of
                                     {error, _}=Err -> Err;
                                     ok ->


### PR DESCRIPTION
Master contains many compiler warnings about unused variables (and a couple other related issues):

```
jkakar@rex:~/src/github.com/jkakar/alpaca:master$ rebar3 compile
===> Verifying dependencies...
===> Compiling alpaca
/Users/jkakar/src/github.com/jkakar/alpaca/_build/default/lib/alpaca/src/alpaca_parser.yrl: Warning: conflicts: 60 shift/reduce, 0 reduce/reduce
/Users/jkakar/src/github.com/jkakar/alpaca/_build/default/lib/alpaca/src/alpaca_parser.yrl:none: Warning: conflicts: 60 shift/reduce, 0 reduce/reduce

src/alpaca_typer.erl:700: Warning: variable 'Ms' is unused
src/alpaca_typer.erl:800: Warning: variable 'Env' is unused
src/alpaca_typer.erl:800: Warning: variable 'Line' is unused
src/alpaca_typer.erl:835: Warning: variable 'Link' is unused
src/alpaca_typer.erl:910: Warning: variable 'E' is unused
src/alpaca_typer.erl:1146: Warning: variable 'R' is unused
src/alpaca_typer.erl:1367: Warning: variable 'L' is unused
src/alpaca_typer.erl:1367: Warning: variable 'Lvl' is unused
src/alpaca_typer.erl:1504: Warning: variable 'Members' shadowed in 'fun'
src/alpaca_typer.erl:1600: Warning: variable 'Line' is unused
src/alpaca_typer.erl:1750: Warning: variable 'L' is unused
src/alpaca_typer.erl:1808: Warning: a term is constructed, but never used
src/alpaca_typer.erl:2057: Warning: variable 'Recv2' is unused
src/alpaca_typer.erl:2131: Warning: variable 'A' is unused
src/alpaca_typer.erl:2236: Warning: variable 'NN2' is unused
src/alpaca_typer.erl:2258: Warning: variable 'NameNum2' is unused
src/alpaca_typer.erl:2259: Warning: variable 'M' is unused
src/alpaca_typer.erl:2350: Warning: function dump_env/1 is unused
src/alpaca_typer.erl:2355: Warning: function dump_term/1 is unused

src/alpaca_scanner.erl:30: Warning: variable 'Other' is unused

src/alpaca_scan.erl:488: Warning: this clause cannot match because a previous clause at line 484 always matches

src/alpaca_parser.yrl:138: Warning: variable 'L' is unused

src/alpaca_codegen.erl:44: Warning: variable 'Mod' is unused
src/alpaca_codegen.erl:143: Warning: variable 'TopVar' is unused
src/alpaca_codegen.erl:471: Warning: variable 'Env2' is unused

src/alpaca_ast_gen.erl:143: Warning: variable 'ModuleName' is unused
src/alpaca_ast_gen.erl:198: Warning: variable 'MN' is unused
src/alpaca_ast_gen.erl:209: Warning: variable 'M' is unused
src/alpaca_ast_gen.erl:221: Warning: variable 'M' is unused
src/alpaca_ast_gen.erl:345: Warning: variable 'SeedMap' is unused
src/alpaca_ast_gen.erl:345: Warning: a term is constructed, but never used
src/alpaca_ast_gen.erl:351: Warning: variable 'M3' is unused
src/alpaca_ast_gen.erl:426: Warning: variable 'M4' is unused
src/alpaca_ast_gen.erl:481: Warning: variable 'Mod' shadowed in generate
```

This branch removes most of these warnings:

```
jkakar@rex:~/src/github.com/jkakar/alpaca:cleanup-unused-variables-jkakar$ rebar3 compile
===> Verifying dependencies...
===> Compiling alpaca
/Users/jkakar/src/github.com/jkakar/alpaca/_build/default/lib/alpaca/src/alpaca_parser.yrl: Warning: conflicts: 60 shift/reduce, 0 reduce/reduce
/Users/jkakar/src/github.com/jkakar/alpaca/_build/default/lib/alpaca/src/alpaca_parser.yrl:none: Warning: conflicts: 60 shift/reduce, 0 reduce/reduce

src/alpaca_typer.erl:2349: Warning: function dump_env/1 is unused
src/alpaca_typer.erl:2354: Warning: function dump_term/1 is unused

src/alpaca_scan.erl:488: Warning: this clause cannot match because a previous clause at line 484 always matches

src/alpaca_ast_gen.erl:345: Warning: a term is constructed, but never used
```

I've not read the code carefully to see where things can be rewritten to avoid the unused variables; I've simply prepended underscores to shut the compiler up.