### PR TITLE
Add currying

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ modules in Erlang with top-level entities including:
 - type declarations (ADTs)
 - functions which can contain other functions and variables via `let`
 bindings.
+- functions are automatically curried (with some limitations)
 - simple test definitions
 
 An example:

--- a/Tour.md
+++ b/Tour.md
@@ -395,8 +395,9 @@ And here we will always get a list instead of a character list (same ADT restric
 ## Currying <a id="sec-4-3" name="sec-4-3"></a>
 
 Top level functions can be curried. Practically speaking, this means that if
-you do not provide a function with all of its required arguments,
-There are some limitations to this:
+you do not provide a function with all of its required arguments, it instead
+returns another function that takes the remaining arguments. There are some
+limitations to this:
 
 -   If multiple versions of a function are defined, such as `f/2` and `f/3`,
     supplying a single argument to `f` would be ambiguous, so this is disallowed

--- a/Tour.org
+++ b/Tour.org
@@ -322,6 +322,43 @@ let g x =
       l, is_list l -> l
     | c, is_chars c -> c
 #+END_SRC
+** Currying
+
+Top level functions can be curried. Practically speaking, this means that if
+you do not provide a function with all of its required arguments, 
+There are some limitations to this:
+
+- If multiple versions of a function are defined, such as ~f/2~ and ~f/3~, 
+  supplying a single argument to ~f~ would be ambiguous, so this is disallowed
+- Functions defined in ~let... in...~ bindings cannot (currently) be curried
+- When currying a function defined in another module, the function must first
+  be explicitly imported, i.e. ~other_module.my_fun "hello"~ would not work,
+  but ~import other_module.my_fun;; my_fun "hello"~ would.  
+
+The latter two are limitations that should go away in future.
+
+Some examples:
+
+#+BEGIN_SRC
+
+-- Currying means we can use a 'pipe forward' operator to 'chain' expressions
+let (|>) x f = f x
+
+let add a b = a + b
+let sub a b = a - b
+
+let result () =
+  10 |> add 5 |> sub 2 |> add 19
+
+-- We can create predicates for use with higher order functions, e.g.
+let eq x y =
+  x == y
+
+-- assuming a filter/2 function that takens a predicate function and a list 'a
+let filtered_list () =
+  filter (eq 3) [1, 2, 3]
+
+#+END_SRC
 * User Defined Types:  ADTs
 We can currently specify new types by combining existing ones, creating [[https://en.wikipedia.org/wiki/Algebraic_data_type][algebraic data types (ADTs)]].  These new types will also be inferred correctly, here's a simple example of a broad "number" type that combines integers and floats:
 

--- a/Tour.org
+++ b/Tour.org
@@ -59,7 +59,7 @@ let even_or_odd x =
   let rem = x % 2 in
   match rem with
       0 -> Even x
-    | _ -> Odd x 
+    | _ -> Odd x
 #+END_SRC
 Note that variables and function names follow the same format, beginning with a lower-case character.
 * Included Data Types
@@ -80,11 +80,11 @@ Alpaca has integers and floats which can't mix with each other at all.  They hav
 Atoms in Alpaca are just text prefixed with ~:~, e.g. ~:this_is_an_atom~ and ~:soIsThis1~.
 *** Strings
 Strings in Alpaca are all assumed UTF-8 and will be encoded as such:
-#+BEGIN_SRC 
+#+BEGIN_SRC
 "This is a string"
 "so is 한국 and 日本"
-#+END_SRC  
-These are compiled as binaries under the hood.  If you're looking for Erlang's basic string types, character lists can be constructed by prefixing a string with ~c~, for example: 
+#+END_SRC
+These are compiled as binaries under the hood.  If you're looking for Erlang's basic string types, character lists can be constructed by prefixing a string with ~c~, for example:
 #+BEGIN_SRC
 c"character list!"
 #+END_SRC
@@ -159,7 +159,7 @@ let length my_list =
   match my_list with
       [] -> 0
     | _ :: t -> 1 + (length t)
-    
+
 let is_length_3 my_list =
   match my_list with
       [_, _, _] -> true
@@ -167,7 +167,7 @@ let is_length_3 my_list =
 #+END_SRC
 
 *** Maps
-Maps are type-checked as lists are but have separate types for their keys vs their values.  If we wanted a map with atom keys and string values, it could be expressed as the type ~map atom string~.  Functionality is relatively limited still but we can construct literal maps, add single key-value pairs to maps, and pattern match on them.  
+Maps are type-checked as lists are but have separate types for their keys vs their values.  If we wanted a map with atom keys and string values, it could be expressed as the type ~map atom string~.  Functionality is relatively limited still but we can construct literal maps, add single key-value pairs to maps, and pattern match on them.
 #+BEGIN_SRC
 #{:key => "value"}  -- a literal
 
@@ -190,7 +190,7 @@ match {x=1, hello="world"} with
    information about the hello field.  The return type of calling the
    function below with that record will be (int, {x: int, hello: string}).
 -}
-let x_in_a_tuple my_rec = 
+let x_in_a_tuple my_rec =
   match my_rec with
     {x=xx} -> (xx, my_rec)
 #+END_SRC
@@ -205,10 +205,10 @@ public interface IHasX {
 public class HasXY implements IHasX {
     public final int x;
     public final String hello;
-        
+
     public HasXY(int x, String hello) {
         this.x = x;
-        this.hello = hello;  
+        this.hello = hello;
     }
 
     public int getX() { return x; }
@@ -220,7 +220,7 @@ public IHasX identity(IHasX i) {
 }
 #+END_SRC
 
-The return of ~identity(new HasXY(1, "world"))~ "loses" the information that the passed-in argument has a ~hello~ member of type ~String~.  
+The return of ~identity(new HasXY(1, "world"))~ "loses" the information that the passed-in argument has a ~hello~ member of type ~String~.
 
 #+BEGIN_SRC
 let identity my_rec =
@@ -325,15 +325,16 @@ let g x =
 ** Currying
 
 Top level functions can be curried. Practically speaking, this means that if
-you do not provide a function with all of its required arguments, 
-There are some limitations to this:
+you do not provide a function with all of its required arguments, it instead
+returns another function that takes the remaining arguments. There are some
+limitations to this:
 
-- If multiple versions of a function are defined, such as ~f/2~ and ~f/3~, 
+- If multiple versions of a function are defined, such as ~f/2~ and ~f/3~,
   supplying a single argument to ~f~ would be ambiguous, so this is disallowed
 - Functions defined in ~let... in...~ bindings cannot (currently) be curried
 - When currying a function defined in another module, the function must first
   be explicitly imported, i.e. ~other_module.my_fun "hello"~ would not work,
-  but ~import other_module.my_fun;; my_fun "hello"~ would.  
+  but ~import other_module.my_fun;; my_fun "hello"~ would.
 
 The latter two are limitations that should go away in future.
 
@@ -378,8 +379,8 @@ type opt 'a = Some 'a | None
 
 {- Here's a map "get value by key" function that uses the new `opt` type.
    It's polymorphic in that if we give this function a `map string int`
-   and a string for `key`, the return type will be an `opt int`.  If we 
-   instead give it a `map atom (list string)` and an atom for the key, 
+   and a string for `key`, the return type will be an `opt int`.  If we
+   instead give it a `map atom (list string)` and an atom for the key,
    the return type will be `opt (list string)`.
 -}
 let map_get key the_map =
@@ -420,7 +421,7 @@ let f x =
     | f, is_float f -> :float
 #+END_SRC
 * Tests
-Support for tests inside source files is currently at its most basic with the goal of keeping unit tests alongside the functions they're testing directly rather than in a separate file.  
+Support for tests inside source files is currently at its most basic with the goal of keeping unit tests alongside the functions they're testing directly rather than in a separate file.
 
 Tests:
 
@@ -477,10 +478,10 @@ A basic example will probably help:
 let a_counting_function x =
   receive with
       "add" -> a_counting_function x + 1
-    | "sub" -> a_counting_function x - 1 
+    | "sub" -> a_counting_function x - 1
 
 {- If a_counting_function/1 is exported from the module, the following
-   will spawn a `pid string`, that is, a "process that can receive 
+   will spawn a `pid string`, that is, a "process that can receive
    strings".  Note that this is not a valid top-level entry for a module,
    we just want a few simple examples.
  -}
@@ -496,7 +497,7 @@ send :add my_pid
 The type inferencer looks at the entire call graph of the function being spawned to determine type of messages that the process is capable of receiving.  Any expression that contains a call to ~receive~ becomes a "receiver" that carries the type of messages handled so if we have something like ~let x = receive with i, is_integer i -> i~, that entire expression is a receiver.  If a function contains it like this:
 
 #+BEGIN_SRC
-let f x = 
+let f x =
   let x = receive with i, is_integer i -> i in
   i
 #+END_SRC

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -391,4 +391,11 @@ curry_test() ->
     ?assertEqual({16,26,[2]}, M:foo(unit)),
     code:delete(M).
 
+curry_import_export_test() ->
+    Files = ["test_files/curry.alp", "test_files/curry_import.alp"],
+    [M1, M2] = compile_and_load(Files, []),
+    ?assertEqual([3], M1:run_filter(unit)),
+    code:delete(M1),
+    code:delete(M2).
+
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -386,4 +386,9 @@ function_in_adt_test() ->
     ?assertEqual(true, M:test_int_dict({})),
     code:delete(M).
 
+curry_test() ->
+    [M] = compile_and_load(["test_files/curry.alp"], []),
+    ?assertEqual({16,26,[2]}, M:foo(unit)),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -134,7 +134,7 @@
 -type alpaca_binary() :: #alpaca_binary{}.
 
 -type alpaca_bits_type() :: int | float | binary | utf8.
-
+ 
 -record(alpaca_bits, {line=0 :: integer(),
                     %% Used to signal whether or not the bitstring is simply
                     %% using default size and unit values.  If it is *not*
@@ -379,6 +379,7 @@
 %%% Expressions that result in values:
 -type alpaca_value_expression() :: alpaca_const()
                                | alpaca_symbol()
+                               | alpaca_far_ref()
                                | alpaca_list()
                                | alpaca_binary()
                                | alpaca_map()

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -109,9 +109,9 @@
 -type alpaca_bool() :: {bool, integer(), boolean()}.
 -type alpaca_atom() :: {atom, integer(), atom()}.
 
--type alpaca_error() :: {raise_error, 
-                       integer(), 
-                       throw|error|exit, 
+-type alpaca_error() :: {raise_error,
+                       integer(),
+                       throw|error|exit,
                        alpaca_value_expression()}.
 
 %%% The variable _, meaning "don't care":
@@ -134,7 +134,7 @@
 -type alpaca_binary() :: #alpaca_binary{}.
 
 -type alpaca_bits_type() :: int | float | binary | utf8.
- 
+
 -record(alpaca_bits, {line=0 :: integer(),
                     %% Used to signal whether or not the bitstring is simply
                     %% using default size and unit values.  If it is *not*
@@ -197,7 +197,7 @@
 
 -record(t_record, {members=[] :: list(t_record_member()),
                            row_var=undefined :: typ()}).
-                           
+
 -type t_record() :: #t_record{}.
 
 %%% ADT Type Tracking

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -346,7 +346,7 @@ gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
     Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
     case Expr of
         %% Detect far refs that require currying
-        {alpaca_far_ref, _, _, _, Arity} when Arity > length(Args) ->
+        #alpaca_far_ref{arity=Arity} when Arity > length(Args) ->
             CArgs = lists:map(
                fun(A) -> 
                     {symbol, L, "carg_" ++ integer_to_list(A)}

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -742,4 +742,17 @@ module_info_helpers_test() ->
     ?assert(is_list(Mod:module_info())),
     true = code:delete(Mod).
 
+curry_test() ->
+    Code = 
+        "module curry\n"
+        "let f x y = x + y\n"
+        "let main () = \n"
+        "  let f_ = f 10 in\n"
+        "  f_ 6",
+    {ok, _, Bin} = parse_and_gen(Code),
+    Mod = curry,
+    {module, Mod} = code:load_binary(Mod, "alpaca_curry.beam", Bin),
+    ?assertEqual(Mod:main(unit), 16),
+    true = code:delete(Mod).
+
 -endif.

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -28,11 +28,11 @@
 %%   - names of top-level functions with their arity
 %%   - incrementing variable number for wildcard variables (underscores)
 %%   - numbers for synthesized function name generation
-%% 
-%% The top-level functions get looked up for correct Core Erlang call 
+%%
+%% The top-level functions get looked up for correct Core Erlang call
 %% construction.  Renaming instances of "_" (the wildcard or "don't care"
 %% variable name) is necessary because "_" is actually a legitimate variable
-%% name in Core Erlang.  If we don't rename it when there are multiple 
+%% name in Core Erlang.  If we don't rename it when there are multiple
 %% occurrences in the same pattern there will be a compilation error from
 %% the 'cerl' module.
 -record(env, {
@@ -45,7 +45,7 @@ make_env(#alpaca_module{functions=Funs}=_Mod) ->
     TopLevelFuns = [{N, A} || #alpaca_fun_def{name={symbol, _, N}, arity=A} <- Funs],
     #env{module_funs=TopLevelFuns, wildcard_num=0}.
 
-prefix_modulename(Name) ->    
+prefix_modulename(Name) ->
     case Name of
         erlang -> erlang;
         _ -> list_to_atom("alpaca_" ++ atom_to_list(Name))
@@ -58,7 +58,7 @@ gen(#alpaca_module{}=Mod, Opts) ->
        functions=Funs,
        tests=Tests} = Mod,
     Env = make_env(Mod),
-    PrefixModuleName = prefix_modulename(ModuleName), 
+    PrefixModuleName = prefix_modulename(ModuleName),
     {Env2, CompiledFuns} = gen_funs(Env, [], Funs),
     CompiledTests = gen_tests(Env2, Tests),
 
@@ -95,9 +95,9 @@ gen_funs(Env, Funs, [#alpaca_fun_def{}=F|T]) ->
     NewF = gen_fun(Env, F),
     gen_funs(Env, [NewF|Funs], T).
 
-gen_fun(Env, 
+gen_fun(Env,
         #alpaca_fun_def{
-           name={symbol, _, N}, 
+           name={symbol, _, N},
            versions=[#alpaca_fun_version{args=[{unit, _}], body=Body}]}) ->
 
     FName = cerl:c_fname(list_to_atom(N), 1),
@@ -113,7 +113,7 @@ gen_fun(Env, #alpaca_fun_def{name={symbol, _, N}, versions=Vs}=Def) ->
                 false ->
                     FName = cerl:c_fname(list_to_atom(N), length(Args)),
                     A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
-                    {_, B} = gen_expr(Env, Body),                    
+                    {_, B} = gen_expr(Env, Body),
                     {FName, cerl:c_fun(A, B)};
                 true ->
                     %% our single version has more than symbols and unit:
@@ -222,11 +222,11 @@ gen_expr(Env, #alpaca_cons{head=H, tail=T}) ->
     {Env3, T2} = gen_expr(Env2, T),
     {Env3, cerl:c_cons(H2, T2)};
 gen_expr(Env, #alpaca_binary{segments=Segs}) ->
-    {Env2, Bits} = gen_bits(Env, Segs), 
+    {Env2, Bits} = gen_bits(Env, Segs),
     {Env2, cerl:c_binary(Bits)};
 gen_expr(Env, #alpaca_map{is_pattern=true}=M) ->
     Annotated = annotate_map_type(M),
-    F = fun(P, {E, Ps}) -> 
+    F = fun(P, {E, Ps}) ->
                 {E2, P2} = gen_expr(E, P),
                 {E2, [P2|Ps]}
         end,
@@ -299,13 +299,10 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
             %% If we have an exact arity match, use that, otherwise curry
             case lists:filter(fun(X) -> X =:= DesiredArity end, AvailFuns) of
                 [A] -> {cerl:c_fname(list_to_atom(Name), A), false, A};
-                _ ->  
-                    PossibleCurries = lists:filter(fun(X) -> X > DesiredArity end, AvailFuns),
+                _ ->
                     %% The typer ensures that we can curry unambiguously
-                    case PossibleCurries of
-                        [CurryArity] -> 
-                            {cerl:c_fname(list_to_atom(Name), CurryArity), true, CurryArity}
-                    end
+                    [CurryArity] = lists:filter(fun(X) -> X > DesiredArity end, AvailFuns),
+                    {cerl:c_fname(list_to_atom(Name), CurryArity), true, CurryArity}
             end
     end,
     case Curry of
@@ -313,9 +310,9 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
            CurryFunName = "curry_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
            Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
            CArgs = lists:map(
-               fun(A) -> 
+               fun(A) ->
                     {symbol, L, "carg_" ++ integer_to_list(A)}
-               end, 
+               end,
                lists:seq(DesiredArity+1, Arity)),
            CurryExpr = #alpaca_fun_def{
                              name={symbol, L, CurryFunName},
@@ -332,15 +329,16 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
 
            gen_expr(Env2, Binding);
 
-        false -> Apply = cerl:c_apply(
-                    FName, 
-                    [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
-    {               Env, Apply}
+        false ->
+            Apply = cerl:c_apply(
+                        FName,
+                        [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
+                        {Env, Apply}
     end;
 gen_expr(Env, #alpaca_apply{expr={{symbol, _L, N}, Arity}, args=Args}) ->
     FName = cerl:c_fname(list_to_atom(N), Arity),
     Apply = cerl:c_apply(
-              FName, 
+              FName,
               [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
     {Env, Apply};
 gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
@@ -350,9 +348,9 @@ gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
         %% Detect far refs that require currying
         #alpaca_far_ref{arity=Arity} when Arity > length(Args) ->
             CArgs = lists:map(
-               fun(A) -> 
+               fun(A) ->
                     {symbol, L, "carg_" ++ integer_to_list(A)}
-               end, 
+               end,
                lists:seq(length(Args)+1, Arity)),
                CurryExpr = #alpaca_fun_def{
                              name={symbol, L, FunName},
@@ -452,11 +450,11 @@ gen_expr(Env, #alpaca_spawn{from_module=M,
                           function={symbol, _, FN},
                           args=Args}) ->
 
-    ArgCons = lists:foldl(fun(A, L) -> 
+    ArgCons = lists:foldl(fun(A, L) ->
                                   {_, AExp} = gen_expr(Env, A),
-                                  cerl:c_cons(AExp, L) 
+                                  cerl:c_cons(AExp, L)
                           end, cerl:c_nil(), lists:reverse(Args)),
-    PrefixModuleName = prefix_modulename(M), 
+    PrefixModuleName = prefix_modulename(M),
     {Env, cerl:c_call(
             cerl:c_atom('erlang'),
             cerl:c_atom('spawn'),
@@ -562,9 +560,9 @@ record_to_map(#alpaca_record{line=RL, is_pattern=Patt, members=Ms}) ->
                 MapK = {atom, L, atom_to_list(N)},
                 #alpaca_map_pair{line=L, is_pattern=Patt, key=MapK, val=MapV}
         end,
-    #alpaca_map{is_pattern=Patt, 
+    #alpaca_map{is_pattern=Patt,
               structure=record,
-              line=RL, 
+              line=RL,
               pairs=lists:map(F, Ms)};
 record_to_map(NotRecord) ->
     NotRecord.
@@ -748,7 +746,7 @@ ffi_test() ->
         "  1 -> :one\n"
         "| _ -> :not_one\n",
     {ok, _, Bin} = parse_and_gen(Code),
-    {module, alpaca_ffi_test} = code:load_binary(alpaca_ffi_test, 
+    {module, alpaca_ffi_test} = code:load_binary(alpaca_ffi_test,
                                                  "alpaca_ffi_test.beam", Bin),
 
     Mod = alpaca_ffi_test,
@@ -806,7 +804,7 @@ module_info_helpers_test() ->
     true = code:delete(Mod).
 
 curry_test() ->
-    Code = 
+    Code =
         "module autocurry\n"
         "export main\n"
         "let f x y = x + y\n"

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -113,7 +113,7 @@ gen_fun(Env, #alpaca_fun_def{name={symbol, _, N}, versions=Vs}=Def) ->
                 false ->
                     FName = cerl:c_fname(list_to_atom(N), length(Args)),
                     A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
-                    {_, B} = gen_expr(Env, Body),
+                    {_, B} = gen_expr(Env, Body),                    
                     {FName, cerl:c_fun(A, B)};
                 true ->
                     %% our single version has more than symbols and unit:
@@ -197,6 +197,7 @@ gen_expr(#env{module_funs=Funs}=Env, {symbol, _, V}) ->
         0 ->
             {Env, cerl:c_apply(cerl:c_fname(list_to_atom(V), 0), [])};
         Arity when is_integer(Arity) ->
+            %% Do we have a function with the right arity?
             {Env, cerl:c_fname(list_to_atom(V), Arity)};
         undefined ->
             {Env, cerl:c_var(list_to_atom(V))}
@@ -288,17 +289,52 @@ gen_expr(Env, #alpaca_apply{expr={symbol, _Line, Name}, args=[{unit, _}]}) ->
                 1 -> cerl:c_fname(list_to_atom(Name), 1)
             end,
     {Env, cerl:c_apply(FName, [cerl:c_atom(unit)])};
-gen_expr(Env, #alpaca_apply{expr={symbol, _Line, Name}, args=Args}) ->
-    FName = case proplists:get_value(Name, Env#env.module_funs) of
-                undefined ->
-                    cerl:c_var(list_to_atom(Name));
-                Arity ->
-                    cerl:c_fname(list_to_atom(Name), Arity)
-            end,
-    Apply = cerl:c_apply(
-              FName, 
-              [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
-    {Env, Apply};
+gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
+    DesiredArity = length(Args),
+    {FName, Curry, Arity} = case proplists:get_all_values(Name, Env#env.module_funs) of
+        [] -> {cerl:c_var(list_to_atom(Name)), false, 0};
+        AvailFuns ->
+            %% If we have an exact arity match, use that, otherwise curry
+            case lists:filter(fun(X) -> X =:= DesiredArity end, AvailFuns) of
+                [A] -> {cerl:c_fname(list_to_atom(Name), A), false, A};
+                _ ->  
+                    PossibleCurries = lists:filter(fun(X) -> X > DesiredArity end, AvailFuns),
+                    %% The typer ensures that we can curry unambiguously
+                    case PossibleCurries of
+                        [CurryArity] -> 
+                            {cerl:c_fname(list_to_atom(Name), CurryArity), true, CurryArity}
+                    end
+            end
+    end,
+    case Curry of
+        true -> %% generate an anonymous fun
+           CurryFunName = "curry_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
+           Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
+           CArgs = lists:map(
+               fun(A) -> 
+                    {symbol, L, "carg_" ++ integer_to_list(A)}
+               end, 
+               lists:seq(DesiredArity+1, Arity)),
+           CurryExpr = #alpaca_fun_def{
+                             name={symbol, L, CurryFunName},
+                             arity=DesiredArity,
+                             versions=[#alpaca_fun_version{
+                                          args=CArgs,
+                                          body=#alpaca_apply{
+                                            line=L,
+                                            expr=FExpr,
+                                            args=Args ++ CArgs}}]},
+           Binding = #fun_binding{
+                        expr={symbol, L, CurryFunName},
+                        def=CurryExpr},
+
+           gen_expr(Env2, Binding);
+
+        false -> Apply = cerl:c_apply(
+                    FName, 
+                    [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
+    {               Env, Apply}
+    end;
 gen_expr(Env, #alpaca_apply{expr={{symbol, _L, N}, Arity}, args=Args}) ->
     FName = cerl:c_fname(list_to_atom(N), Arity),
     Apply = cerl:c_apply(
@@ -744,15 +780,16 @@ module_info_helpers_test() ->
 
 curry_test() ->
     Code = 
-        "module curry\n"
+        "module autocurry\n"
+        "export main\n"
         "let f x y = x + y\n"
         "let main () = \n"
-        "  let f_ = f 10 in\n"
+        "  let f_ = f 5 in\n"
         "  f_ 6",
     {ok, _, Bin} = parse_and_gen(Code),
-    Mod = curry,
-    {module, Mod} = code:load_binary(Mod, "alpaca_curry.beam", Bin),
-    ?assertEqual(Mod:main(unit), 16),
+    Mod = alpaca_autocurry,
+    {module, Mod} = code:load_binary(Mod, "alpaca_autocurry.beam", Bin),
+    ?assertEqual(Mod:main(unit), 11),
     true = code:delete(Mod).
 
 -endif.

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -344,12 +344,37 @@ gen_expr(Env, #alpaca_apply{expr={{symbol, _L, N}, Arity}, args=Args}) ->
 gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
     FunName = "synth_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
     Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
-    SynthBinding = #var_binding{
-                      name={symbol, L, FunName},
-                      to_bind=Expr,
-                      expr=#alpaca_apply{line=L, expr={symbol, L, FunName}, args=Args}},
+    case Expr of
+        %% Detect far refs that require currying
+        {alpaca_far_ref, _, _, _, Arity} when Arity > length(Args) ->
+            CArgs = lists:map(
+               fun(A) -> 
+                    {symbol, L, "carg_" ++ integer_to_list(A)}
+               end, 
+               lists:seq(length(Args)+1, Arity)),
+               CurryExpr = #alpaca_fun_def{
+                             name={symbol, L, FunName},
+                             arity=length(Args),
+                             versions=[#alpaca_fun_version{
+                                          args=CArgs,
+                                          body=#alpaca_apply{
+                                            line=L,
+                                            expr=Expr,
+                                            args=Args ++ CArgs}}]},
+               Binding = #fun_binding{
+                        expr={symbol, L, FunName},
+                        def=CurryExpr},
+               gen_expr(Env2, Binding);
+        _ ->
+            SynthBinding = #var_binding{
+                              name={symbol, L, FunName},
+                              to_bind=Expr,
+                              expr=#alpaca_apply{
+                                        line=L, expr={symbol, L, FunName},
+                                        args=Args}},
 
-    gen_expr(Env2, SynthBinding);
+            gen_expr(Env2, SynthBinding)
+    end;
 
 gen_expr(Env, #alpaca_ffi{}=FFI) ->
     #alpaca_ffi{

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -95,6 +95,7 @@ Rootsymbol expr.
 
 Unary 500 minus.
 Unary 500 plus.
+Left 200 infixable.
 
 
 %% Comments are stripped in the AST assembly right now but I want them
@@ -330,7 +331,6 @@ tuple -> '(' tuple_list ')' :
   #alpaca_tuple{arity=length('$2'), values='$2'}.
 
 infix -> term op term : make_infix('$2', '$1', '$3').
-infix -> term infixable term : make_infix('$2', '$1', '$3').
 
 %% ----- Errors (including throw, exit) --------------
 error -> raise_error term:
@@ -522,6 +522,7 @@ simple_expr -> receive_block : '$1'.
 simple_expr -> ffi_call : '$1'.
 simple_expr -> guard : '$1'.
 simple_expr -> spawn_pid : '$1'.
+simple_expr -> simple_expr infixable simple_expr : make_infix('$2', '$1', '$3').
 
 expr -> comment : '$1'.
 expr -> simple_expr : '$1'.

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1662,7 +1662,7 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
             catch
                 error:{arity_error, _, _} -> 
                     case Expr of
-                        {alpaca_far_ref, _, _, _, _} = E -> CurryFun(E);
+                        #alpaca_far_ref{} -> CurryFun({error, uncurryable_far_ref});
                         _ -> ForwardFun()
                     end
             end        

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1594,6 +1594,25 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
     %% (e.g. a symbol or bif), attempt to find it in the module.
     %% This ForwardFun function is used specifically to find functions defined
     %% later than the application we're trying to type.
+    CurryFun = 
+        fun(OriginalErr) ->
+            %% Attempt to find a curryable version
+            FN = case Expr of
+                    {symbol, Line, FunName} -> FunName;
+                    {bif, FunName, _, _, _} -> FunName
+            end,
+            CurryFuns = get_curryable_funs(Env#env.current_module, FN, length(Args)+1),
+            case CurryFuns of
+                [] -> OriginalErr;
+                [Item] -> case typ_of(Env, Lvl, Item) of
+                                {{t_arrow, TArgs, TRet}, NextVar} ->
+                                    {CurryArgs, RemArgs} = lists:split(length(Args), TArgs),
+                                    CurriedTypF = {t_arrow, CurryArgs, {t_arrow, RemArgs, TRet}},
+                                    typ_apply(Env, Lvl, CurriedTypF, NextVar, Args, L)
+                          end;
+                Items -> {error, {ambiguous_curry, Expr, Items, L}}
+            end
+    end,
     ForwardFun =
         fun() ->
                 FN = case Expr of
@@ -1606,9 +1625,16 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
                         case typ_of(Env, Lvl, Fun) of
                             {error, _}=Err -> Err;
                             {TypF, NextVar} ->
-                                typ_apply(Env, Lvl, TypF, NextVar, Args, L)
+                                %% We should have a t_arrow taking some args with a return value
+                                %% What we need is a t_arrow that takes some of those args and returns
+                                %% another t_arrow taking the remainder and returning the final arg
+                                try
+                                    typ_apply(Env, Lvl, TypF, NextVar, Args, L)
+                                catch
+                                    error:{arity_error, _, _} = Err -> CurryFun(Err)
+                                end
                         end;
-                    {error, _} = E -> E
+                    {error, _} = E -> CurryFun(E)
                 end
         end,
 
@@ -1621,13 +1647,11 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
             %% This does not allow for different arity functions in a sequence 
             %% of let bindings which could be a weakness.
             %%
-            %% TODO:  some arity errors should disappear with support for 
-            %% automatic currying.
             try
                 typ_apply(Env, Lvl, TypF, NextVar, Args, L)
             catch
-                error:{arity_error, _, _} -> ForwardFun()
-            end
+                error:{arity_error, _, _} -> ForwardFun()                                     
+            end        
     end;
 
 %% Unify the patterns with each other and resulting expressions with each
@@ -2099,6 +2123,33 @@ typ_apply_no_recv(Env, Lvl, TypF, NextVar, Args, Line) ->
             end
     end.
 
+typ_apply_curry(Env, Lvl, TypF, NextVar, Args, Line) ->
+    %% we make a deep copy of the function we're unifying
+    %% so that the types we apply to the function don't
+    %% force every other application to unify with them
+    %% where the other callers may be expecting a
+    %% polymorphic function.  See Pierce's TAPL, chapter 22.
+
+    %{CopiedTypF, _} = deep_copy_type(TypF, maps:new()),
+    %% placeholder:
+    CopiedTypF = TypF,
+
+    case typ_list(Args, Lvl, update_counter(NextVar, Env), []) of
+        {error, _}=Err -> Err;
+        {ArgTypes, NextVar2} ->
+            TypRes = new_cell(t_rec),
+            Env2 = update_counter(NextVar2, Env),
+
+            Arrow = new_cell({t_arrow, ArgTypes, TypRes}),
+            case unify(CopiedTypF, Arrow, Env2, Line) of
+                {error, _} = E ->
+                    E;
+                ok ->
+                    #env{next_var=VarNum} = Env2,
+                    {TypRes, VarNum}
+            end
+    end.
+
 -spec extract_fun(
         Env::env(),
         ModuleName::atom(),
@@ -2152,6 +2203,9 @@ get_fun(Module, FunName, Arity) ->
         {ok, Fun} -> {ok, Module, Fun}
     end.
 
+get_curryable_funs(Module, FN, MinArity) ->
+    filter_to_curryable_funs(Module#alpaca_module.functions, FN, MinArity).
+
 filter_to_fun([], _, _) ->
     not_found;
 filter_to_fun([#alpaca_fun_def{name={symbol, _, N}, arity=Arity}=Fun|_], FN, A)
@@ -2159,6 +2213,15 @@ filter_to_fun([#alpaca_fun_def{name={symbol, _, N}, arity=Arity}=Fun|_], FN, A)
     {ok, Fun};
 filter_to_fun([_F|Rem], FN, Arity) ->
     filter_to_fun(Rem, FN, Arity).
+
+filter_to_curryable_funs(Funs, FN, MinArity) ->
+    Pred = fun(#alpaca_fun_def{name={Symbol, _, N}, arity=Arity}) ->
+               case {Arity >= MinArity, N =:= FN} of
+                    {true, true} -> true;
+                    _ -> false
+               end
+           end,
+    lists:filter(Pred, Funs).
 
 %%% for clauses we need to add bindings to the environment for any symbols
 %%% (variables) that occur in the pattern.  "NameNum" is used to give
@@ -4420,4 +4483,63 @@ wait_for_processes_to_die(ExpectedNumProcesses, AttemptsLeft) ->
             timer:sleep(10),
             wait_for_processes_to_die(ExpectedNumProcesses, AttemptsLeft-1)
     end.
+
+curry_applications_test_() ->
+    [fun() ->
+        Code =
+            "module curry\n"
+            "let add a b = a + b\n\n"
+            "let main x = add x\n",
+
+        ?assertMatch(
+            {ok, #alpaca_module{
+                    functions=[#alpaca_fun_def{
+                        type={t_arrow,
+                            [t_int, t_int], t_int}
+                            
+                        },
+                        #alpaca_fun_def{
+                        type={t_arrow,
+                            [t_int], {t_arrow, [t_int], t_int}}
+                        }
+                    ]
+                }
+            },
+        module_typ_and_parse(Code))
+    end,
+    fun() ->
+        Code =
+            "module curry\n"
+            "let main x = add x\n"
+            "let add a b = a + b\n\n",
+
+        ?assertMatch(
+            {ok, #alpaca_module{
+                    functions=[   
+                        #alpaca_fun_def{
+                            type={t_arrow,
+                                    [t_int], {t_arrow, [t_int], t_int}}
+                        },
+                        #alpaca_fun_def{
+                            type={t_arrow,
+                                    [t_int, t_int], t_int}                            
+                        }
+                    ]
+                }
+            },
+        module_typ_and_parse(Code))
+    end,
+    fun() ->
+        Code =
+            "module curry\n"
+            "let main x = add x\n"
+            "let add a b = a + b\n\n"
+            "let add a b c = a + b + c\n\n",
+
+        ?assertMatch(
+            {error, {ambiguous_curry, _, _, _}},
+            module_typ_and_parse(Code))
+    end
+    ].
+
 -endif.

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1590,10 +1590,11 @@ typ_of(Env, Lvl, #alpaca_apply{expr={Mod, {symbol, L, X}, Arity}, args=Args}) ->
     end;
 
 typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
-    %% If the expression we're applying arguments to is a named function
-    %% (e.g. a symbol or bif), attempt to find it in the module.
-    %% This ForwardFun function is used specifically to find functions defined
-    %% later than the application we're trying to type.
+    %% When we hit arity failures, it may be because the user
+    %% is intending a curried application. This function attempts
+    %% to find a potential function that can be unambigiously
+    %% curried, and then types against that by manipulating the
+    %% argument list and return type
     CurryFun = 
         fun(OriginalErr) ->
             %% Attempt to find a curryable version
@@ -1623,6 +1624,10 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
                 Items -> {error, {ambiguous_curry, Expr, Items, L}}
             end
     end,
+    %% If the expression we're applying arguments to is a named function
+    %% (e.g. a symbol or bif), attempt to find it in the module.
+    %% This ForwardFun function is used specifically to find functions defined
+    %% later than the application we're trying to type.
     ForwardFun =
         fun() ->
                 FN = case Expr of

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -280,9 +280,9 @@ deep_copy_type({t_map, K, V}, RefMap) ->
 
 deep_copy_type({t_receiver, A, B}, RefMap) ->
     %% Here we're copying the body of the receiver first and then the
-    %% receiver type itself, explicitly with a method that pulls existing 
-    %% reference cells for named type variables from the map returned by 
-    %% the body's deep copy operation.  This ensures that when the same 
+    %% receiver type itself, explicitly with a method that pulls existing
+    %% reference cells for named type variables from the map returned by
+    %% the body's deep copy operation.  This ensures that when the same
     %% type variable occurs in body the body and receive types we use the
     %% same reference cell.
     {B2, M2} = deep_copy_type(B, RefMap),
@@ -342,23 +342,23 @@ unify_error(Env, Line, Typ1, Typ2) ->
 %%% Unify now requires the environment not in order to make changes to it but
 %%% so that it can look up potential type unions when faced with unification
 %%% errors.
-%%% 
-%%% For the purposes of record unification, T1 is considered to be the lower 
+%%%
+%%% For the purposes of record unification, T1 is considered to be the lower
 %%% bound for unification.  Example:
-%%% 
+%%%
 %%% a: {x: int, y: int}  -- a row variable `A` is implied.
 %%% f: {x: int|F} -> (int, {x: int|F})
-%%% 
+%%%
 %%% Calling f(a) given the above poses no problem.  The two `x` members unify
 %%% and the `F` in f's type unifies with `y: int|A`.  But:
-%%% 
+%%%
 %%% b: {x: int}  - a row variable `B` is implied.
 %%% f: {x: int, y: int|F} -> (int, {x: int, y: int|F})
-%%% 
-%%% Here `f` is more specific than `b` and _requires_ a `y: int` member.  Its 
-%%% type must serve as a lower bound for unification, we don't want `f(b)` to 
+%%%
+%%% Here `f` is more specific than `b` and _requires_ a `y: int` member.  Its
+%%% type must serve as a lower bound for unification, we don't want `f(b)` to
 %%% succeed if the implied row variable `B` does not contain a `y: int`.
-%%% 
+%%%
 %%% Some of the packing into and unpacking from row variables is likely to get
 %%% a little hairy in the first implementation here.
 -spec unify(typ(), typ(), env(), integer()) -> ok | {error, term()}.
@@ -663,7 +663,7 @@ unify_adt(_C1, _C2,
                                   ({{_, X}, {_, Y}}, ok) -> unify(L, X, Y, Env)
                                end,
                     lists:foldl(UnifyFun, ok, lists:zip(VarsA, ToCheck));
-                _ -> 
+                _ ->
                     unify_error(Env, L, A, B)
             end
     end;
@@ -694,7 +694,7 @@ unify_adt_and_poly(C1, C2, #adt{members=Ms}=A, ToCheck, Env, L) when is_pid(ToCh
         end,
     Seed = unify_error(Env, L, A, ToCheck),
     lists:foldl(F, Seed, Ms);
-%% ToCheck needs to be in a reference cell for unification and we're not 
+%% ToCheck needs to be in a reference cell for unification and we're not
 %% worried about losing the cell at this level since C1 and C2 are what
 %% will actually be manipulated.
 unify_adt_and_poly(C1, C2, #adt{members=_Ms}=A, ToCheck, Env, L) ->
@@ -790,7 +790,7 @@ unify_records(LowerBound, Target, Env, Line) ->
 
     %% unify the row variables
     case RemainingTarget of
-        [] -> 
+        [] ->
             unify(LowerRow, TargetRow, Env, Line);
         _ ->
             NewTarget = new_cell(#t_record{members=RemainingTarget, row_var=TargetRow}),
@@ -806,9 +806,9 @@ unify_record_members([LowerBound|Rem], TargetRem, Env, Line) ->
             erlang:error({missing_record_field, Line, N});
         #t_record_member{type=T2} ->
             case unify(T, T2, Env, Line) of
-                {error, _}=Err -> 
+                {error, _}=Err ->
                     erlang:error(Err);
-                ok -> 
+                ok ->
                     NewTargetRem = proplists:delete(N, TargetRem),
                     unify_record_members(Rem, NewTargetRem, Env, Line)
             end
@@ -819,12 +819,12 @@ unify_record_members([LowerBound|Rem], TargetRem, Env, Line) ->
 %% need to unpack these row variables to unify records predictably and
 %% also upon completion of typing.  Problems could occur when unifying the
 %% following:
-%% 
+%%
 %% #t_record{members={x, t_int}, row_var=#t_record{members={y, t_int}}, ...}
 %% #t_record{members={y, t_int}, row_var=#t_record{members={x, t_int}}, ...}
 %%
 %% Because the members that need unifying (coming from either record to the
-%% other) are effectively hidden in their respective row variables, 
+%% other) are effectively hidden in their respective row variables,
 %% unify_record_members won't see them directly.
 flatten_record(#t_record{members=Ms, row_var=#t_record{}=Inner}) ->
     #t_record{members=InnerMs, row_var=InnerRow} = Inner,
@@ -899,7 +899,7 @@ inst_type_members(ADT, [{alpaca_map, KExp, VExp}|Rem], Env, Memo) ->
 inst_type_members(ADT, [#t_record{}=R|Rem], Env, Memo) ->
     #t_record{members=Ms, row_var=RV} = R,
     {RVC, Env2} = case RV of
-                      undefined -> 
+                      undefined ->
                           {V, E} = new_var(0, Env),
                           {new_cell(V), E};
                       {unbound, _, _}=V ->
@@ -909,9 +909,9 @@ inst_type_members(ADT, [#t_record{}=R|Rem], Env, Memo) ->
                   end,
     F = fun(#t_record_member{type=T}=M, {NewMems, _E}) ->
                 case inst_type_members(ADT, [T], Env, []) of
-                    {error, _}=Err -> 
+                    {error, _}=Err ->
                         erlang:error(Err);
-                    {ok, E2, _, [InstT]} -> 
+                    {ok, E2, _, [InstT]} ->
                         {[M#t_record_member{type=InstT}|NewMems], E2}
                 end
         end,
@@ -999,7 +999,7 @@ inst_type_arrow(EnvIn, {type_constructor, Line, Name}) ->
                 ({C, {ok, Env, ADT, _}}) ->
                      #adt{vars=Vs} = get_cell(ADT),
                      #alpaca_constructor{arg=Arg} = C,
-                     %% We need to include types from other modules even if 
+                     %% We need to include types from other modules even if
                      %% they're not exported so that types we *have* imported
                      %% that depend on those we've not can still be instantiated
                      %% correctly:
@@ -1049,10 +1049,10 @@ inst_constructor_arg(#alpaca_type{name={type_name, _, N}, vars=Vars, members=M1}
     %% when a polymorphic ADT occurs in another type's definition it might
     %% have concrete types assigned rather than variables and thus we want
     %% to find the original/biggest list of vars for the type.  E.g.
-    %% 
+    %%
     %% type option 'a = Some 'a | None
     %% type either_int 'a = Left 'a | Right option int
-    %% 
+    %%
     VarsToUse = case length(V2) > length(Vars) of
                     true -> V2;
                     false -> Vars
@@ -1222,7 +1222,7 @@ retrieve_type(SourceModule, Module, Type, []) ->
     throw(missing_type_error(SourceModule, Module, Type));
 retrieve_type(SM, M, T, [#alpaca_module{name=M, types=Ts, type_exports=ETs}|Rem]) ->
     case [TT || #alpaca_type{name={type_name, _, TN}}=TT <- Ts, TN =:= T] of
-        [#alpaca_type{name={_, _, TN}}=Type] -> 
+        [#alpaca_type{name={_, _, TN}}=Type] ->
             %% now make sure the type is exported:
             case [X || X <- ETs, X =:= TN] of
                 [_] -> {ok, Type};
@@ -1503,7 +1503,7 @@ typ_of(Env, Lvl, #alpaca_map_add{line=L, to_add=A, existing=B}) ->
 typ_of(Env, Lvl, #alpaca_record{members=Members}) ->
     F = fun(#alpaca_record_member{name=N, val=V}, {ARMembers, E}) ->
                 case typ_of(E, Lvl, V) of
-                    {error, _}=Err -> 
+                    {error, _}=Err ->
                         erlang:error(Err);
                     {VTyp, NextVar} ->
                         MTyp = #t_record_member{name=N, type=VTyp},
@@ -1559,14 +1559,14 @@ typ_of(Env, Lvl, #alpaca_apply{expr={Mod, {symbol, L, X}, Arity}, args=Args}) ->
                         %% Type the called function in its own module:
                         case type_module(Module, Env2) of
                             {ok, #alpaca_module{functions=Funs}} ->
-                                [T] = [Typ || 
-                                          #alpaca_fun_def{name={symbol, _, N}, arity=A, type=Typ} <- Funs, 
-                                          N =:= X, 
+                                [T] = [Typ ||
+                                          #alpaca_fun_def{name={symbol, _, N}, arity=A, type=Typ} <- Funs,
+                                          N =:= X,
                                           A =:= Arity
                                       ],
                                 #env{next_var=NextVar}=Env,
                                 %% deep copy to cell the various types, needed
-                                %% because typing a module unwraps all the 
+                                %% because typing a module unwraps all the
                                 %% reference cells before returning the module:
                                 {DT, _} = deep_copy_type(T, maps:new()),
                                 typ_apply(Env, Lvl, DT, NextVar, Args, L);
@@ -1595,16 +1595,16 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
     %% to find a potential function that can be unambigiously
     %% curried, and then types against that by manipulating the
     %% argument list and return type
-    CurryFun = 
+    CurryFun =
         fun(OriginalErr) ->
             %% Attempt to find a curryable version
             {Mod, FN, Env2} = case Expr of
-                {symbol, _Line, FunName} -> 
+                {symbol, _Line, FunName} ->
                     {Env#env.current_module, FunName, Env};
-                
-                {bif, FunName, _, _, _} -> 
+
+                {bif, FunName, _, _, _} ->
                     {Env#env.current_module, FunName, Env};
-                
+
                 {alpaca_far_ref, _, ModName, FunName, _} ->
                     EnteredModules = [Env#env.current_module | Env#env.entered_modules],
                     {ok, Module, _} = extract_module_bindings(Env, ModName, FunName),
@@ -1646,7 +1646,7 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
                                 try
                                     typ_apply(Env, Lvl, TypF, NextVar, Args, L)
                                 catch
-                                    error:{arity_error, _, _} = Err -> CurryFun(Err)
+                                    throw:{arity_error, _, _} = Err -> CurryFun(Err)
                                 end
                         end;
                     {error, _} = E -> CurryFun(E)
@@ -1655,22 +1655,22 @@ typ_of(Env, Lvl, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
 
     case typ_of(Env, Lvl, Expr) of
         {error, {bad_variable_name, _}} -> ForwardFun();
-        {error, _} = E -> E;            
+        {error, _} = E -> E;
         {TypF, NextVar} ->
             %% If the function in the environment is the wrong arity we want to
             %% try to locate a matching one in the module.
-            %% This does not allow for different arity functions in a sequence 
+            %% This does not allow for different arity functions in a sequence
             %% of let bindings which could be a weakness.
             %%
             try
                 typ_apply(Env, Lvl, TypF, NextVar, Args, L)
             catch
-                error:{arity_error, _, _} -> 
+                error:{arity_error, _, _} ->
                     case Expr of
                         #alpaca_far_ref{} -> CurryFun({error, uncurryable_far_ref});
                         _ -> ForwardFun()
                     end
-            end        
+            end
     end;
 
 %% Unify the patterns with each other and resulting expressions with each
@@ -1792,7 +1792,7 @@ typ_of(Env, Lvl, #alpaca_spawn{line=_L, module=undefined, function=F, args=Args}
                             case _AT of
                                 {t_receiver, Recv2, _} ->
                                     {new_cell({t_pid, Recv2}), NV2};
-                                _ -> 
+                                _ ->
                                     {new_cell({t_pid, Recv}), NV2}
                                 end;
                         _ ->
@@ -1814,7 +1814,7 @@ typ_of(EnvIn, Lvl, #alpaca_fun_def{name={symbol, L, N}, versions=Vs}) ->
                 JustTypes = lists:reverse(RevTyps),
                 RecursiveType = {t_arrow, JustTypes, new_cell(t_rec)},
                 EnvWithLetRec = update_binding(N, RecursiveType, Env2),
-                
+
                 case typ_of(EnvWithLetRec, Lvl, Body) of
                     {error, _} = Err ->
                         Err;
@@ -1822,20 +1822,20 @@ typ_of(EnvIn, Lvl, #alpaca_fun_def{name={symbol, L, N}, versions=Vs}) ->
                         case unwrap(T) of
                             {t_receiver, Recv, Res} ->
                                 TRec = {t_receiver, new_cell(Recv), new_cell(Res)},
-                                {t_receiver, Recv2, Res2} = 
+                                {t_receiver, Recv2, Res2} =
                                     collapse_receivers(TRec, Env2, Lvl),
                                 X = {t_receiver, Recv2,
                                       {t_arrow, JustTypes, Res2}},
                                 {[X|Types], update_counter(NextVar, Env2)};
                             _ ->
                                 %% Nullary funs are really values - for type
-                                %% checking we're only interested in their 
+                                %% checking we're only interested in their
                                 %% return value
                                 case JustTypes of
                                     [] -> {[T|Types], update_counter(NextVar, Env2)};
                                     _  -> {[{t_arrow, JustTypes, T}|Types],
                                           update_counter(NextVar, Env2)}
-                                end                         
+                                end
                         end
                 end
         end,
@@ -1852,8 +1852,8 @@ typ_of(EnvIn, Lvl, #alpaca_fun_def{name={symbol, L, N}, versions=Vs}) ->
                                     {error, _}=Err -> Err;
                                     ok -> T2
                                 end
-                        end, 
-                        H, 
+                        end,
+                        H,
                         TypedVersions),
             case Unified of
                 {error, _}=Err -> Err;
@@ -2488,8 +2488,8 @@ infix_arrow_types_test_() ->
     [?_assertMatch({{t_arrow, [t_int], t_int}, _},
                    top_typ_of("let (<*>) x = x + x"))
     , ?_assertMatch({{t_arrow, [A, {t_arrow, [A], B}], B}, _},
-                    top_typ_of("let (|>) x f = f x"))  
-    ].    
+                    top_typ_of("let (|>) x f = f x"))
+    ].
 
 simple_polymorphic_let_test() ->
     Code =
@@ -3143,7 +3143,7 @@ type_constructor_with_arrow_arg_test() ->
             "let p x y = x > y\n\n"
             "let make () = Constructor p",
      ?assertMatch({ok, _}, module_typ_and_parse(Valid)),
-    
+
     Invalid = Base ++
               "let p x y = x + y\n\n"
               "let make () = Constructor p",
@@ -3581,7 +3581,7 @@ polymorphic_process_as_return_value_test() ->
     ?assertMatch({error, {cannot_unify, poly_process, 12, t_float, t_atom}}, Res).
 
 polymorphic_spawn_test() ->
-    FunCode = 
+    FunCode =
         "let behaviour state state_f =\n"
         "  receive with\n"
         "    x -> behaviour (state_f state x) state_f",
@@ -3592,10 +3592,10 @@ polymorphic_spawn_test() ->
                   {unbound,t2,0},
                   {t_arrow,
                    [{unbound,t0,0},
-                    {t_arrow, 
+                    {t_arrow,
                      [{unbound,t0,0},{unbound,t2,0}],
                      {unbound,t0,0}}],
-                   t_rec}}, 
+                   t_rec}},
                  FunType),
     NewBindings = [{"behaviour", FunType}|BaseEnv#env.bindings],
     NewModule = #alpaca_module{functions=[FunExp#alpaca_fun_def{type=FunType}]},
@@ -3603,7 +3603,7 @@ polymorphic_spawn_test() ->
     SpawnCode = "let f x y = x +. y in spawn behaviour 1.0 f",
     {ok, SpawnExp} = alpaca_ast_gen:parse(alpaca_scanner:scan(SpawnCode)),
     {SpawnType, _} = typ_of(EnvWithFun,  SpawnExp),
-                            
+
     ?assertMatch({t_pid, t_float}, SpawnType).
 
 
@@ -3910,7 +3910,7 @@ record_inference_test_() ->
              Code =
                  "let f r = match r with\n"
                  "  {x = x1} -> x1 + 1",
-             ?assertMatch({{t_arrow, 
+             ?assertMatch({{t_arrow,
                             [#t_record{
                                  members=[#t_record_member{
                                              name=x,
@@ -3925,7 +3925,7 @@ record_inference_test_() ->
                  "let f r = match r with\n"
                  "  {x = x1} -> (x1 * 2, r)\n\n"
                  "let g () = f {x=1, y=2}",
-             ?assertMatch({ok, 
+             ?assertMatch({ok,
                            #alpaca_module{
                               functions=[#alpaca_fun_def{
                                             name={symbol, _, "f"},
@@ -3973,7 +3973,7 @@ record_inference_test_() ->
                  "    {x=x1, a=a1} -> x1 + a1\n"
                  "  | Adt -> 0",
              ?assertMatch(
-                {ok, 
+                {ok,
                  #alpaca_module{
                     functions=[#alpaca_fun_def{
                                   type={t_arrow,
@@ -3990,7 +3990,7 @@ record_inference_test_() ->
                                                         row_var={unbound, _, _}},
                                                     {t_adt_cons, "Adt"}]
                                                        }],
-                                            t_int}}]}}, 
+                                            t_int}}]}},
                     module_typ_and_parse(Code))
      end,
      fun() ->
@@ -4017,20 +4017,20 @@ record_inference_test_() ->
 %% and records in the definition of a type impacts the unification and thus
 %% inference of a function's return type.  This test is to check for multiple
 %% orderings and regressions.
-%% 
+%%
 %% The root error appears to have been arising because in unify_adt_and_poly
 %% one of the target type members was unwrapped from its reference cell.  Since
 %% the unification was actually impacting the top level cells, we could re-cell
 %% the type and not worry about throwing that away later.
 adt_ordering_test_() ->
     [fun() ->
-             Code = 
+             Code =
                  "module simple_adt_order_1\n\n"
                  "type t 'a = Some 'a | None\n\n"
                  "let f x = match x with\n"
                  "    None -> :none\n"
                  "  | Some a -> :an_a",
-             ?assertMatch({ok, 
+             ?assertMatch({ok,
                            #alpaca_module{
                               functions=[#alpaca_fun_def{
                                             type={t_arrow,
@@ -4042,13 +4042,13 @@ adt_ordering_test_() ->
                           module_typ_and_parse(Code))
      end
     ,fun() ->
-             Code = 
+             Code =
                  "module simple_adt_order_2\n\n"
                  "type t 'a = None | Some 'a\n\n"
                  "let f x = match x with\n"
                  "    None -> :none\n"
                  "  | Some a -> :an_a",
-             ?assertMatch({ok, 
+             ?assertMatch({ok,
                            #alpaca_module{
                               functions=[#alpaca_fun_def{
                                             type={t_arrow,
@@ -4069,7 +4069,7 @@ adt_ordering_test_() ->
                   "let g () = f #{:a => 1, :b => 2}\n\n"
                   "let h () = f [1, 2]",
               ?assertMatch(
-                 {ok, 
+                 {ok,
                   #alpaca_module{
                      functions=[#alpaca_fun_def{
                                    type={t_arrow,
@@ -4093,7 +4093,7 @@ adt_ordering_test_() ->
                  "let g () = f #{:a => 1, :b => 2}\n\n"
                  "let h () = f [1, 2]",
               ?assertMatch(
-                 {ok, 
+                 {ok,
                   #alpaca_module{
                      functions=[#alpaca_fun_def{
                                    type={t_arrow,
@@ -4152,7 +4152,7 @@ adt_ordering_test_() ->
 
 unify_with_error_test_() ->
     [fun() ->
-             Code = 
+             Code =
                  "module unify_with_error_test\n\n"
                  "let throw_on_zero x = match x with "
                  "    0 -> throw :zero"
@@ -4164,7 +4164,7 @@ unify_with_error_test_() ->
                 module_typ_and_parse(Code))
      end
      , fun() ->
-               Code = 
+               Code =
                    "module unify_with_error_test\n\n"
                    "let should_not_unify x = match x with "
                    "    0 -> throw :zero"
@@ -4221,8 +4221,8 @@ function_argument_pattern_test_() ->
                          functions=[#alpaca_fun_def{
                                        versions=[_, _],
                                        type={t_arrow,
-                                             [{t_arrow, 
-                                               [{unbound, A, _}], 
+                                             [{t_arrow,
+                                               [{unbound, A, _}],
                                                {unbound, B, _}},
                                               #adt{vars=[{_, {unbound, A, _}}]}],
                                              #adt{vars=[{_, {unbound, B, _}}]}}}]}},
@@ -4310,7 +4310,7 @@ constrain_polymorphic_adt_funs_test_() ->
                   "  let rec = {x=1, y=2} in "
                   "  my_map doubler (get_x rec)",
               ?assertMatch(
-                 {ok, 
+                 {ok,
                  #alpaca_module{
                     functions=[#alpaca_fun_def{
                                   type={t_arrow,
@@ -4327,7 +4327,7 @@ constrain_polymorphic_adt_funs_test_() ->
                                                         type={unbound, C, _}}]}],
                                         #adt{vars=[{_, {unbound, C, _}}]}}},
                                #alpaca_fun_def{
-                                  type={t_arrow, 
+                                  type={t_arrow,
                                         [t_unit],
                                         #adt{vars=[{"a", t_int}]}}}]
                    }},
@@ -4337,14 +4337,14 @@ constrain_polymorphic_adt_funs_test_() ->
 
 different_arity_test_() ->
     [fun() ->
-             Code = 
+             Code =
                  "module arity_test\n\n"
                  "let add x = x + x\n\n"
                  "let add x y = x + y",
              ?assertMatch({ok, #alpaca_module{}}, module_typ_and_parse(Code))
      end
     , fun() ->
-              Code = 
+              Code =
                   "module arity_test\n\n"
                   "export add/2\n\n"
                   "let add x = x + x\n"
@@ -4352,24 +4352,24 @@ different_arity_test_() ->
               ?assertMatch({ok, #alpaca_module{}}, module_typ_and_parse(Code))
       end
     , fun() ->
-              Code = 
+              Code =
                   "module arity_test\n\n"
                   "export add/1\n\n"
                   "let add x = x + x\n"
                   "let f x y = add x y",
               ?assertMatch(
-                 {error, {not_found, _, "add", 2}}, 
+                 {error, {not_found, _, "add", 2}},
                  module_typ_and_parse(Code))
       end
     , fun() ->
-              Code = 
+              Code =
                   "module arity_test\n\n"
                   "export add/1\n\n"
                   "let add x = "
                   "let f a b = a + b in "
                   "f x",
               ?assertMatch(
-                 {error, {not_found, _, SyntheticName, 1}}, 
+                 {error, {not_found, _, SyntheticName, 1}},
                  module_typ_and_parse(Code))
       end
     ].
@@ -4386,7 +4386,7 @@ types_in_types_test_() ->
     [fun() ->
              %% Without importing `symbol` we should be fine if we're not
              %% referencing its constructor directly:
-             FormatterCode = 
+             FormatterCode =
                  "module formatter\n\n"
                  "import_type types_in_types.expr\n\n"
                  "import_type types_in_types.ast\n\n"
@@ -4395,12 +4395,12 @@ types_in_types_test_() ->
 
              [M1, M2] = alpaca_ast_gen:make_modules([AstCode, FormatterCode]),
              ?assertMatch(
-                {ok, [#alpaca_module{}, #alpaca_module{}]}, 
+                {ok, [#alpaca_module{}, #alpaca_module{}]},
                 type_modules([M1, M2]))
      end
     , fun() ->
               %% Importing `symbol` and not using it should be fine:
-              FormatterCode = 
+              FormatterCode =
                   "module formatter\n\n"
                   "import_type types_in_types.symbol\n\n"
                   "import_type types_in_types.expr\n\n"
@@ -4410,13 +4410,13 @@ types_in_types_test_() ->
 
               [M1, M2] = alpaca_ast_gen:make_modules([AstCode, FormatterCode]),
               ?assertMatch(
-                 {ok, [#alpaca_module{}, #alpaca_module{}]}, 
+                 {ok, [#alpaca_module{}, #alpaca_module{}]},
                  type_modules([M1, M2]))
       end
     , fun() ->
-              %% NOT importing `symbol` and then trying to use its type 
+              %% NOT importing `symbol` and then trying to use its type
               %% constructor should yield an error:
-              FormatterCode = 
+              FormatterCode =
                   "module formatter\n\n"
                   "import_type types_in_types.expr\n\n"
                   "import_type types_in_types.ast\n\n"
@@ -4439,9 +4439,9 @@ types_in_types_test_() ->
                   "type expr = symbol | Apply (expr, expr) "
                   "| Match {e: expr, clauses: list {pattern: expr, result: expr}}\n\n"
                   "type ast = expr | Fun {name: symbol, arity: int, body: expr}\n\n",
-              
+
               %% Importing `symbol` should let us use the constructor:
-              FormatterCode = 
+              FormatterCode =
                   "module formatter\n"
                   "import_type types_in_types.symbol\n"
                   "import_type types_in_types.expr\n"
@@ -4461,16 +4461,16 @@ types_in_types_test_() ->
 expression_typing_test_() ->
     [%% `1` is not a function from an int to something else:
      ?_assertMatch(
-        {error, {cannot_unify, _, _, t_int, {t_arrow, [t_int], _}}}, 
+        {error, {cannot_unify, _, _, t_int, {t_arrow, [t_int], _}}},
         top_typ_of("1 2")),
-     ?_assertMatch({{t_arrow, [t_unit], t_int}, _}, 
+     ?_assertMatch({{t_arrow, [t_unit], t_int}, _},
                    top_typ_of(
                      "let g () = "
                      "let f x = x + x in "
                      "let g () = f in "
                      "(g ()) 2"
                     ))
-     
+
     ].
 
 no_process_leak_test() ->
@@ -4506,7 +4506,7 @@ curry_applications_test_() ->
                     functions=[#alpaca_fun_def{
                         type={t_arrow,
                             [t_int, t_int], t_int}
-                            
+
                         },
                         #alpaca_fun_def{
                         type={t_arrow,
@@ -4525,14 +4525,14 @@ curry_applications_test_() ->
 
         ?assertMatch(
             {ok, #alpaca_module{
-                    functions=[   
+                    functions=[
                         #alpaca_fun_def{
                             type={t_arrow,
                                     [t_int], {t_arrow, [t_int], t_int}}
                         },
                         #alpaca_fun_def{
                             type={t_arrow,
-                                    [t_int, t_int], t_int}                            
+                                    [t_int, t_int], t_int}
                         }
                     ]
                 }

--- a/test_files/curry.alp
+++ b/test_files/curry.alp
@@ -1,0 +1,39 @@
+module curry
+
+export foo/1
+export filter
+export (|>)
+
+let (|>) x f = f x
+
+let non_curry x =
+  x + x
+
+let add x y = 
+  x + y
+
+let whatever i a =
+  i
+
+let filter_ pred l acc =
+  match l with
+      [] -> acc
+    | hd :: tail ->
+        match pred hd with
+            true  -> filter_ pred tail hd :: acc
+          | false -> filter_ pred tail acc
+
+let filter pred l =
+  filter_ pred l []
+
+let eq a b =
+  a == b
+
+let filtered_list () =    
+  [1, 2, 3]
+  |> filter (eq 2)
+
+let foo () =
+  let adder = add 6 in
+  (whatever 6 "yeh" |> add 5 |> add 5, adder 20, filtered_list ())
+

--- a/test_files/curry_import.alp
+++ b/test_files/curry_import.alp
@@ -5,8 +5,8 @@ export run_filter
 import curry.filter
 import curry.(|>)
 
-let pred x = 
-    x == 3
+let eq x y = 
+    x == y
 
 let run_filter () =
-    [1, 2, 3] |> filter pred
+    [1, 2, 3] |> filter (eq 3)

--- a/test_files/curry_import.alp
+++ b/test_files/curry_import.alp
@@ -1,0 +1,12 @@
+module curry_import
+
+export run_filter
+
+import curry.filter
+import curry.(|>)
+
+let pred x = 
+    x == 3
+
+let run_filter () =
+    [1, 2, 3] |> filter pred


### PR DESCRIPTION
This PR enables currying, where there aren't conflicts between multi-arity functions and curried applications in the manner discussed in #74.

Currying is currently enabled only for top level functions, and far references must also be imported before being curried. In future these limitations should be easy enough to remove, and the addition of anonymous functions to Alpaca will also help see more benefit from currying.

The curries themselves are generated as anonymous functions at the call site to minimise polluting modules and conflicts.

If a user attempts to curry in a way that the compiler cannot resolve unambiguously (say, passing two arguments to function `f` when both `f/3` and `f/5` are defined) then the compiler provides an error, listing the ambiguous curries.

This PR also contains some alterations to the parser to allow infix arguments to take expressions as arguments, not simply terms. This means that in combination with currying infix functions can be used to delineate expressions, reducing parenthesis usage (e.g, chaining |>, or using <| as in Elm or $ as in Haskell to avoid needing to nest expressions in parentheses).

Here is an example (adapted from curry.alp in the test_files) that demonstrates some of what this now enables.

```elm
module curry

-- Infix 'pipe forward' operator
let (|>) x f = f x

let add x y = 
  x + y

let filter_ pred l acc =
  match l with
      [] -> acc
    | hd :: tail ->
        match pred hd with
            true  -> filter_ pred tail hd :: acc
          | false -> filter_ pred tail acc

let filter pred l =
  filter_ pred l []

-- Currying this means we can create an '=' predicate function for use in filter/2
let eq a b =
  a == b

let filtered_list () =    
  [1, 2, 3] -- without currying, the pipe below would fail
  |> filter (eq 2)

let foo () =
  let adder = add 6 in
  (6 |> add 5 |> add 5, adder 20, filtered_list ())
```

Shout outs to @danabr, @OvermindDL1, @yurrriq, @saem, and of course @j14159 for their considerable amount of thought and participation on this issue.