### PR TITLE
Bugfix: Added the ability to refer to 'chars' and '()'  in type specs.

### DIFF
--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -158,6 +158,7 @@ type_expr -> '[' type_list ']' '->' type_expr :
 type_expr -> base_type :
   {base_type, _, T} = '$1',
   list_to_atom("t_" ++ T).
+type_expr -> unit : t_unit.
 type_expr -> base_list type_expr:
   {alpaca_list, '$2'}.
 type_expr -> base_map type_expr type_expr : {alpaca_map, '$2', '$3'}.
@@ -669,6 +670,8 @@ is_literal({boolean, _, _}) -> true;
 is_literal({chars, _, _}) -> true;
 is_literal({alpaca_tuple, _, _, Members}) ->
     all_literals(Members);
+is_literal({unit, _}) ->
+    true;
 is_literal(_) -> false.
 
 all_literals([]) -> true;

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -29,7 +29,7 @@ BRK = \n(\n)+
 FLOAT_MATH = (\+\.)|(\-\.)|(\*\.)|(\/\.)
 TYPE_CHECK = is_integer|is_float|is_atom|is_bool|is_list|is_string|is_chars|is_pid|is_binary
 
-BASE_TYPE = atom|int|float|string|bool|binary
+BASE_TYPE = atom|int|float|string|bool|binary|chars
 BASE_LIST = list
 BASE_MAP = map
 BASE_PID = pid

--- a/test_files/values.alp
+++ b/test_files/values.alp
@@ -2,9 +2,12 @@ module values
 
 export test_values/1
 
-type simple_adt = AnInt int | AString string
+type simple_adt = AnInt int | AString string | AFloat float |
+                  ARecord { x: int } | ABinary binary | AList (list int) |
+                  AnADT simple_adt | AnAtom atom | ABool bool | Chars chars |
+                  ATuple (int, string) | Unit ()
 
-let test_int = 41 
+let test_int = 41
 let test_string = "Vicugna pacos"
 let test_float = 0.5
 let test_record = {x = 19}
@@ -15,6 +18,20 @@ let test_atom = :nope
 let test_bool = true
 let test_chars = c"x"
 let test_tuple = (100, "100")
+let test_unit = ()
+
+let wrapped_int = AnInt 41
+let wrapped_string = AString "Vicugna pacos"
+let wrapped_float = AFloat 0.5
+let wrapped_record = ARecord {x = 19}
+let wrapped_binary = ABinary <<1: size=8, 2: size=8>>
+let wrapped_array = AList [1, 2, 3, 4]
+let wrapped_adt = AnADT (AnInt 5)
+let wrapped_atom = AnAtom :nope
+let wrapped_bool = ABool true
+let wrapped_chars = Chars c"x"
+let wrapped_tuple = ATuple (100, "100")
+let wrapped_unit = Unit ()
 
 -- Note the use of the value of test_int in an expression
 let test_values () = (test_int + 1, test_string)


### PR DESCRIPTION
Also made sure these are accepted as literals.