### PR TITLE
Rewrite variables in raised errors

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -397,4 +397,11 @@ curry_import_export_test() ->
     code:delete(M1),
     code:delete(M2).
 
+throw_with_variables_test() ->
+    Files = ["test_files/asserts.alp"],
+    [M] = compile_and_load(Files, []),
+    ?assertEqual(true, M:assert_equal(2, 2)),
+    ?assertThrow({not_equal, 1, 2}, M:assert_equal(1, 2)),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -710,6 +710,9 @@ rename_bindings(Env, M, #alpaca_clause{pattern=P, guards=Gs, result=R}=Clause) -
                     end
             end
     end;
+rename_bindings(Env, Map, {raise_error, Line, Kind, Expr}) ->
+    {Env2, Map2, Expr2} = rename_bindings(Env, Map, Expr),
+    {Env2, Map2, {raise_error, Line, Kind, Expr2}};
 rename_bindings(Env, Map, Expr) ->
     {Env, Map, Expr}.
 

--- a/test_files/asserts.alp
+++ b/test_files/asserts.alp
@@ -5,4 +5,4 @@ export assert_equal/2
 let assert_equal a b =
   match (a == b) with
       true  -> true
-    | false -> throw (:not_equal, a, b)  
+    | false -> throw (:not_equal, a, b)

--- a/test_files/asserts.alp
+++ b/test_files/asserts.alp
@@ -1,0 +1,8 @@
+module asserts
+
+export assert_equal/2
+
+let assert_equal a b =
+  match (a == b) with
+      true  -> true
+    | false -> throw (:not_equal, a, b)  


### PR DESCRIPTION
Fixes #68.  Previously variables in terms that were raised as throws,
errors, or exits weren't rewritten during AST generation, leading to
compilation errors on the Core Erlang side.