### PR TITLE
Concrete type parameters for types as type members

### DIFF
--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -231,7 +231,8 @@
           line=0 :: integer(),
           module=undefined :: atom(),
           name={type_name, -1, ""} :: alpaca_type_name(),
-          vars=[]                  :: list(alpaca_type_var()),
+          vars=[]                  :: list(alpaca_type_var()
+                                           | {alpaca_type_var(), typ()}),
           members=[]               :: list(alpaca_constructor()
                                            | alpaca_type_var()
                                            | alpaca_types())

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1616,7 +1616,10 @@ ambiguous_type_expressions_test() ->
                          vars=[],
                          members=[#alpaca_type{
                                      name={type_name,1,"foo"},
-                                     vars=[],
+                                     vars=[{_, #alpaca_type{
+                                                  name={type_name, _, "bar"}}},
+                                           {_, #alpaca_type{
+                                                  name={type_name, _, "baz"}}}],
                                      members=[#alpaca_type{
                                                  name={type_name,1,"bar"},
                                                  vars=[],
@@ -1631,10 +1634,15 @@ ambiguous_type_expressions_test() ->
                          vars=[],
                          members=[#alpaca_type{
                                      name={type_name,1,"foo"},
-                                     vars=[],
+                                     vars=[{_,
+                                            #alpaca_type{
+                                               name={type_name, _, "bar"},
+                                               vars=[{_,
+                                                      #alpaca_type{
+                                                        name={_, _, "baz"}}}]}}],
                                      members=[#alpaca_type{
                                                  name={type_name,1,"bar"},
-                                                 vars=[],
+                                                 vars=[_],
                                                  members=[#alpaca_type{
                                                              name={type_name,1,"baz"},
                                                              vars=[],

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -869,7 +869,12 @@ inst_type(Typ, EnvIn) ->
     #alpaca_type{name={type_name, _, N}, module=Mod, vars=Vs, members=Ms} = Typ,
     VarFolder = fun({type_var, _, VN}, {Vars, E}) ->
                         {TVar, E2} = new_var(0, E),
-                        {[{VN, TVar}|Vars], E2}
+                        {[{VN, TVar}|Vars], E2};
+                   ({{type_var, _, VN}, Expr}, {Vars, E}) ->
+                        %% copy_cell/1 should put every nested member properly
+                        %% into its own reference cell:
+                        {Celled, _} = copy_cell(Expr, maps:new()),
+                        {[{VN, Celled}|Vars], E}
                 end,
     {Vars, Env} = lists:foldl(VarFolder, {[], EnvIn}, Vs),
     ParentADT = #adt{name=N, module=Mod, vars=lists:reverse(Vars)},
@@ -940,6 +945,7 @@ inst_type_members(#adt{vars=Vs}=ADT, [{type_var, L, N}|T], Env, Memo) ->
         {error, _}=Err -> Err;
         Typ -> inst_type_members(ADT, T, Env, [Typ|Memo])
     end;
+
 inst_type_members(ADT, [#alpaca_type_tuple{members=Ms}|T], Env, Memo) ->
     case inst_type_members(ADT, Ms, Env, []) of
         {error, _}=Err ->
@@ -1104,10 +1110,15 @@ inst_constructor_arg(#alpaca_type{name={type_name, _, N}, vars=Vars, members=M1}
                     false -> Vars
                 end,
 
-    ADT_vars = [{VN, proplists:get_value(VN, Vs)} || {type_var, _, VN} <- VarsToUse],
+    F = fun({type_var, _, VN}) ->
+                {VN, proplists:get_value(VN, Vs)};
+           ({{type_var, _, _}, _}=ConcreteType) ->
+                ConcreteType
+        end,
+    ADT_Vars = lists:map(F, VarsToUse),
     Vs2 = replace_vars(M1, V2, Vs),
     Members = lists:map(fun(M) -> inst_constructor_arg(M, Vs2, Types) end, M2),
-    new_cell(#adt{name=N, vars=ADT_vars, members=Members, module=Mod});
+    new_cell(#adt{name=N, vars=ADT_Vars, members=Members, module=Mod});
 
 inst_constructor_arg({t_arrow, ArgTypes, RetType}, Vs, Types) ->
     InstantiatedArgs =  [ inst_constructor_arg(A, Vs, Types) || A <- ArgTypes ],
@@ -3210,7 +3221,7 @@ type_constructor_with_aliased_arrow_arg_test() ->
                          #adt{name="intbinop",
                               vars=[],
                               members=[#adt{name="binop",
-                                            vars=[{"a",undefined}],
+                                            vars=[{_, t_int}],
                                             members=[{t_arrow,[t_int,t_int],t_int}]}]},
                           {t_arrow,[t_int,t_atom],t_rec}}},
                   module_typ_and_parse(Invalid)).
@@ -4667,6 +4678,34 @@ curry_applications_test_() ->
             {error, {ambiguous_curry, _, _, _}},
             module_typ_and_parse(Code))
     end
+    ].
+
+%% For issue #113, we want to be able to define a polymorphic type and use it
+%% as a member in another type but with a concrete type rather than variables,
+%% e.g.
+%%
+%% type option 'a = Some 'a | None
+%% type int_option = option 'a
+%%
+concrete_type_parameters_test_() ->
+    [fun() ->
+             Code =
+                 "module concrete_option\n"
+                 "type opt 'a = Some 'a | None\n"
+                 "type uses_opt = Uses opt int\n"
+                 "let f () = Uses Some 1",
+             ?assertMatch({ok, #alpaca_module{}},
+                          module_typ_and_parse(Code))
+     end,
+     fun() ->
+             Code =
+                 "module should_not_unify "
+                 "type opt 'a = Some 'a | None "
+                 "type uses_opt = Uses opt int "
+                 "let f () = Uses Some 1.0",
+             ?assertMatch({error, {cannot_unify, _, _, t_float, t_int}},
+                          module_typ_and_parse(Code))
+     end
     ].
 
 -endif.


### PR DESCRIPTION
Fixes #113 

Lets us write:

    type option 'a  = Some 'a | None
    type int_opt = IntOpt option int

and actually use `int_opt`.  Prior to this fix using `int_opt`, e.g. like `IntOpt Some 1` would fail to type as it tried to unify `t_int` and `undefined`.  We weren't capturing `int` as a value for a type variable.

cc/ @danabr for review as we've discussed this fix prior.