### PR TITLE
Remove {alpaca_list, T} in favor of {t_list, T}.

### DIFF
--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -175,17 +175,12 @@
          }).
 -type alpaca_type_tuple() :: #alpaca_type_tuple{}.
 
-%% Explicit built-in list type for use in ADT definitions.
--type alpaca_list_type() :: {alpaca_list,
-                           alpaca_base_type()|alpaca_poly_type()}.
-
 -type alpaca_map_type() :: {alpaca_map,
                           alpaca_base_type()|alpaca_poly_type(),
                           alpaca_base_type()|alpaca_poly_type()}.
 
 -type alpaca_poly_type() :: alpaca_type()
                         | alpaca_type_tuple()
-                        | alpaca_list_type()
                         | alpaca_map_type().
 
 %%% ### Record Type Tracking
@@ -224,7 +219,6 @@
 -type alpaca_types() :: alpaca_type()
                     | alpaca_type_tuple()
                     | alpaca_base_type()
-                    | alpaca_list_type()
                     | alpaca_map_type().
 
 -record(alpaca_type, {

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -195,7 +195,7 @@ sub_type_expr -> base_type :
   list_to_atom("t_" ++ T).
 sub_type_expr -> unit : t_unit.
 type_expr -> base_list sub_type_expr:
-  {alpaca_list, '$2'}.
+  {t_list, '$2'}.
 sub_type_expr -> base_map sub_type_expr sub_type_expr : {alpaca_map, '$2', '$3'}.
 sub_type_expr -> base_pid sub_type_expr :
   {alpaca_pid, '$2'}.

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -888,7 +888,7 @@ inst_type_members(ParentADT, [], Env, FinishedMembers) ->
 %% single atom types are passed unchanged (built-in types):
 inst_type_members(ParentADT, [H|T], Env, Memo) when is_atom(H) ->
     inst_type_members(ParentADT, T, Env, [new_cell(H)|Memo]);
-inst_type_members(ADT, [{alpaca_list, TExp}|Rem], Env, Memo) ->
+inst_type_members(ADT, [{t_list, TExp}|Rem], Env, Memo) ->
     case inst_type_members(ADT, [TExp], Env, []) of
         {error, _}=Err -> Err;
         {ok, Env2, _, [InstMem]} ->
@@ -1087,7 +1087,7 @@ inst_constructor_arg(#alpaca_constructor{name=#type_constructor{name=N}},
     {t_adt_cons, N};
 inst_constructor_arg(#alpaca_type_tuple{members=Ms}, Vs, Types) ->
     new_cell({t_tuple, [inst_constructor_arg(M, Vs, Types) || M <- Ms]});
-inst_constructor_arg({alpaca_list, ElementType}, Vs, Types) ->
+inst_constructor_arg({t_list, ElementType}, Vs, Types) ->
     new_cell({t_list, inst_constructor_arg(ElementType, Vs, Types)});
 inst_constructor_arg({alpaca_map, KeyType, ValType}, Vs, Types) ->
     new_cell({t_map, inst_constructor_arg(KeyType, Vs, Types),
@@ -3155,7 +3155,7 @@ type_constructor_test_() ->
               vars=[],
               members=[#alpaca_constructor{
                           name=#type_constructor{line=1, name="Constructor"},
-                          arg={alpaca_list, t_int}}]}])),
+                          arg={t_list, t_int}}]}])),
      ?_assertMatch(
         {{t_arrow,
           [{unbound, _, _}],


### PR DESCRIPTION
Having two representations is confusing.