### PR TITLE
Bugfix 91

### DIFF
--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1431,7 +1431,7 @@ validate_types(
     #alpaca_type{name={_, L, N}, vars=Vs, members=Ms}=H,
     case [TN || TN <- TypeNames, TN =:= N] of
         [] ->
-            throw({invalid_type, ModName, L, N});
+            throw({unknown_type, ModName, L, N});
         _ ->
             validate_types(ModName, TypeNames, Modules, Ms),
             validate_types(ModName, TypeNames, Modules, Vs),
@@ -1445,7 +1445,7 @@ validate_types(MN, Ts, Mods, [#alpaca_type{}=T|Rem]) ->
         [#alpaca_module{types=Xs}] ->
             case [X || #alpaca_type{name={_, _, Y}}=X <- Xs, Y =:= N] of
                 [] -> 
-                    throw({invalid_type, MN, L, N});
+                    throw({unknown_type, MN, L, N});
                 [_] ->
                     [] = validate_types(MN, Ts, Mods, Vs),
                     validate_types(MN, Ts, Mods, Rem)
@@ -4932,7 +4932,7 @@ error_on_missing_types_test_() ->
              Code =
                  "module m \n"
                  "type t = b",
-             ?assertMatch({error, {invalid_type, m, 2, "b"}},
+             ?assertMatch({error, {unknown_type, m, 2, "b"}},
                           module_typ_and_parse(Code))
      end
      , fun() ->
@@ -4940,42 +4940,42 @@ error_on_missing_types_test_() ->
                    "module m \n"
                    "type t 'a = A 'a \n"
                    "type u = t b",
-               ?assertMatch({error, {invalid_type, m, 3, "b"}},
+               ?assertMatch({error, {unknown_type, m, 3, "b"}},
                             module_typ_and_parse(Code))
        end
     , fun() ->
               Code =
                   "module m \n"
                   "type t = T b",
-              ?assertMatch({error, {invalid_type, m, 2, "b"}},
+              ?assertMatch({error, {unknown_type, m, 2, "b"}},
                             module_typ_and_parse(Code))
       end
     , fun() ->
               Code =
                   "module m \n"
                   "type t = (int, b)",
-              ?assertMatch({error, {invalid_type, m, 2, "b"}},
+              ?assertMatch({error, {unknown_type, m, 2, "b"}},
                             module_typ_and_parse(Code))
       end
     , fun() ->
               Code =
                   "module m \n"
                   "type t = {x: b}",
-              ?assertMatch({error, {invalid_type, m, 2, "b"}},
+              ?assertMatch({error, {unknown_type, m, 2, "b"}},
                             module_typ_and_parse(Code))
       end
     , fun() ->
               Code =
                   "module m \n"
                   "type t = T int | list b",
-              ?assertMatch({error, {invalid_type, m, 2, "b"}},
+              ?assertMatch({error, {unknown_type, m, 2, "b"}},
                             module_typ_and_parse(Code))
       end
     , fun() ->
               Code =
                   "module m \n"
                   "type t = map atom c",
-              ?assertMatch({error, {invalid_type, m, 2, "c"}},
+              ?assertMatch({error, {unknown_type, m, 2, "c"}},
                             module_typ_and_parse(Code))
       end
     , fun() ->
@@ -5010,7 +5010,7 @@ error_on_missing_types_test_() ->
               M1 = "module m",
               M2 = "module n \n type t = m.a",
               Mods = alpaca_ast_gen:make_modules([M1, M2]),
-              ?assertMatch({error, {invalid_type, n, 2, "a"}},
+              ?assertMatch({error, {unknown_type, n, 2, "a"}},
                             type_modules(Mods))
       end
     ].

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1045,7 +1045,7 @@ inst_type_arrow(EnvIn, #type_constructor{}=TC) ->
                     M = [AM || #alpaca_module{name=N}=AM <- Mods, Mod =:= N],
                     case M of
                         [] ->
-                            #alpaca_module{module=MN} = Env#env.current_module,
+                            #alpaca_module{name=MN} = EnvIn#env.current_module,
                             throw({error, {bad_module, MN, Line, Mod}});
                         [Target] ->
                             %% in the beginning of typing, constructors/1 links
@@ -1463,7 +1463,7 @@ validate_types(MN, Ts, Mods, [#alpaca_type{}=T|Rem]) ->
 validate_types(MN, Ts, Mods, [#t_record{members=Ms}|T]) ->
     MemberTypes = [Type || #t_record_member{type=Type} <- Ms],
     validate_types(MN, Ts, Mods, MemberTypes ++ T);
-validate_types(M, TNs, Mods, [{alpaca_list, LT}|T]) ->
+validate_types(M, TNs, Mods, [{t_list, LT}|T]) ->
     [] = validate_types(M, TNs, Mods, [LT|T]),
     validate_types(M, TNs, Mods, T);
 validate_types(M, TNs, Mods, [{alpaca_map, KT, VT}|T]) ->
@@ -4677,7 +4677,7 @@ module_qualified_types_test_() ->
                    "module m "
                    "let f n.A x = x + 1",
                [M] = alpaca_ast_gen:make_modules([Code]),
-               ?assertMatch({error, {bad_module, 1, n}}, type_modules([M]))
+               ?assertMatch({error, {bad_module, m, 1, n}}, type_modules([M]))
        end
     ].
 


### PR DESCRIPTION
Fixes #91 

This should catch type members that are:

- bad variable names
- references to types that don't exist in the module or imports
- references to module-qualified types that don't exist