### PR TITLE
Use `{t_map, KeyType, ValType}` consistently to represent the type of…

### DIFF
--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -175,7 +175,7 @@
          }).
 -type alpaca_type_tuple() :: #alpaca_type_tuple{}.
 
--type alpaca_map_type() :: {alpaca_map,
+-type alpaca_map_type() :: {t_map,
                           alpaca_base_type()|alpaca_poly_type(),
                           alpaca_base_type()|alpaca_poly_type()}.
 

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1601,7 +1601,7 @@ ambiguous_type_expressions_test() ->
     ?assertMatch({ok, #alpaca_type{
                          name={type_name,1,"my_map"},
                          vars=[],
-                         members=[{alpaca_map,
+                         members=[{t_map,
                                    #alpaca_type{
                                       name={type_name,1,"foo"},
                                       vars=[],

--- a/src/alpaca_exhaustiveness.erl
+++ b/src/alpaca_exhaustiveness.erl
@@ -132,9 +132,6 @@ covering_patterns({t_list, Elem}, Mod, AllMods, SeenADTs, Vars) ->
 %%
 %% However, to do this, we would need to know all the keys that are used
 %% in the patterns, and we do not get that information from the type.
-covering_patterns({alpaca_map, _KeyT, _ValT}, _Mod, _AllMods, _SeenADTs,
-                  _Vars) ->
-    [t_map];
 covering_patterns({t_map, _KeyT, _ValT}, _Mod, _AllMods, _SeenADTs, _Vars) ->
     [t_map];
 covering_patterns(#t_record{members=Ms}, Mod, AllMods, SeenADTs, Vars) ->

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -196,7 +196,7 @@ sub_type_expr -> base_type :
 sub_type_expr -> unit : t_unit.
 type_expr -> base_list sub_type_expr:
   {t_list, '$2'}.
-sub_type_expr -> base_map sub_type_expr sub_type_expr : {alpaca_map, '$2', '$3'}.
+sub_type_expr -> base_map sub_type_expr sub_type_expr : {t_map, '$2', '$3'}.
 sub_type_expr -> base_pid sub_type_expr :
   {alpaca_pid, '$2'}.
 

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -895,7 +895,7 @@ inst_type_members(ADT, [{t_list, TExp}|Rem], Env, Memo) ->
             inst_type_members(ADT, Rem, Env2,
                               [new_cell({t_list, InstMem})|Memo])
     end;
-inst_type_members(ADT, [{alpaca_map, KExp, VExp}|Rem], Env, Memo) ->
+inst_type_members(ADT, [{t_map, KExp, VExp}|Rem], Env, Memo) ->
     case inst_type_members(ADT, [KExp], Env, []) of
         {error, _}=Err -> Err;
         {ok, Env2, _, [InstK]} ->
@@ -1106,7 +1106,7 @@ inst_constructor_arg(#alpaca_type_tuple{members=Ms}, Vs, Types) ->
     new_cell({t_tuple, [inst_constructor_arg(M, Vs, Types) || M <- Ms]});
 inst_constructor_arg({t_list, ElementType}, Vs, Types) ->
     new_cell({t_list, inst_constructor_arg(ElementType, Vs, Types)});
-inst_constructor_arg({alpaca_map, KeyType, ValType}, Vs, Types) ->
+inst_constructor_arg({t_map, KeyType, ValType}, Vs, Types) ->
     new_cell({t_map, inst_constructor_arg(KeyType, Vs, Types),
                      inst_constructor_arg(ValType, Vs, Types)});
 inst_constructor_arg({alpaca_pid, MsgType}, Vs, Types) ->
@@ -1466,7 +1466,7 @@ validate_types(MN, Ts, Mods, [#t_record{members=Ms}|T]) ->
 validate_types(M, TNs, Mods, [{t_list, LT}|T]) ->
     [] = validate_types(M, TNs, Mods, [LT|T]),
     validate_types(M, TNs, Mods, T);
-validate_types(M, TNs, Mods, [{alpaca_map, KT, VT}|T]) ->
+validate_types(M, TNs, Mods, [{t_map, KT, VT}|T]) ->
     [] = validate_types(M, TNs, Mods, [KT, VT] ++ T),
     validate_types(M, TNs, Mods, T);
 validate_types(M, Ts, Mods, [_H|T]) ->
@@ -3248,7 +3248,7 @@ type_constructor_test_() ->
               vars=[],
               members=[#alpaca_constructor{
                           name=#type_constructor{line=1, name="Constructor"},
-                          arg={alpaca_map, t_int, t_string}}]}])),
+                          arg={t_map, t_int, t_string}}]}])),
      ?_assertMatch(
         {{t_arrow,
           [{unbound, _, _}],


### PR DESCRIPTION
… a map.

Closes #121.