### PR TITLE
Functional record updates

### DIFF
--- a/Tour.md
+++ b/Tour.md
@@ -263,9 +263,9 @@ Records can be created ad-hoc wherever you like as in OCaml and Elm and you can 
       match my_rec with
         {x=xx} -> (xx, my_rec)
 
-1.  Functional Updates
+1.  Record Transformations
 
-    Records can be updated and extended with the same syntax.  If we wanted to add fields `x` and `y` to an existing record `rec`, it's pretty straightforward:
+    Records can be transformed and extended with the same syntax.  Alpaca doesn't consider these "updates" since the original record never changes.  If we wanted to add fields `x` and `y` to an existing record `rec`, it's pretty straightforward:
     
         let a_new_record = {x=1, y=2.0 | rec}
     
@@ -281,9 +281,9 @@ Records can be created ad-hoc wherever you like as in OCaml and Elm and you can 
         let rec1 = {x=1, y=2}
         
         -- {x: string, y: int}
-        let rec2 = {x="hello!", y=2}
+        let rec2 = {x="hello!" | rec1}
     
-    Remember that updating a record actually makes an entirely new one so we allow for members to change type since it's not **actually** a mutation anyhow.
+    Remember that transforming a record actually makes an entirely new one so we allow for members to change type since it's not **actually** a mutation anyhow.   Thanks to <https://github.com/danabr> for the suggestion of "transformation" rather than "update".
     
     There are currently no plans to enable the removal of record fields.
 

--- a/Tour.org
+++ b/Tour.org
@@ -195,8 +195,8 @@ let x_in_a_tuple my_rec =
     {x=xx} -> (xx, my_rec)
 #+END_SRC
 
-**** Functional Updates
-Records can be updated and extended with the same syntax.  If we wanted to add fields ~x~ and ~y~ to an existing record ~rec~, it's pretty straightforward:
+**** Record Transformations
+Records can be transformed and extended with the same syntax.  Alpaca doesn't consider these "updates" since the original record never changes.  If we wanted to add fields ~x~ and ~y~ to an existing record ~rec~, it's pretty straightforward:
 #+BEGIN_SRC
 let a_new_record = {x=1, y=2.0 | rec}
 #+END_SRC
@@ -214,10 +214,10 @@ What happens if we change the type of a field?
 let rec1 = {x=1, y=2}
 
 -- {x: string, y: int}
-let rec2 = {x="hello!", y=2}
+let rec2 = {x="hello!" | rec1}
 #+END_SRC
 
-Remember that updating a record actually makes an entirely new one so we allow for members to change type since it's not *actually* a mutation anyhow.
+Remember that transforming a record actually makes an entirely new one so we allow for members to change type since it's not *actually* a mutation anyhow.   Thanks to https://github.com/danabr for the suggestion of "transformation" rather than "update".
 
 There are currently no plans to enable the removal of record fields.
 

--- a/Tour.org
+++ b/Tour.org
@@ -20,7 +20,7 @@ Much of Alpaca in its current state borrows (in an unstructured manner) aspects 
 While you probably don't need to know any of them in detail, some of the syntax in this document might make a bit more sense if you're familiar with one of the above (including ML).
 
 ** About This Document
-This document is exported from the Emacs org-mode doc ~Tour.org~ using ~org-md-export-to-markdown~.  Corrections and suggestions welcome via PRs to the main [[https://github.com/j14159/alpaca][Alpaca repository]].
+This document is exported from the Emacs org-mode doc ~Tour.org~ using ~org-md-export-to-markdown~.  Corrections and suggestions welcome via PRs to the main [[https://github.com/alpaca-lang/alpaca][Alpaca repository]].
 * The Structure of a Program
 Alpaca at present is really just a new way to write modules for an Erlang application.
 
@@ -195,6 +195,32 @@ let x_in_a_tuple my_rec =
     {x=xx} -> (xx, my_rec)
 #+END_SRC
 
+**** Functional Updates
+Records can be updated and extended with the same syntax.  If we wanted to add fields ~x~ and ~y~ to an existing record ~rec~, it's pretty straightforward:
+#+BEGIN_SRC
+let a_new_record = {x=1, y=2.0 | rec}
+#+END_SRC
+
+Note that the original record ~rec~ has not changed, we have made an entirely new record that contains all of the fields in the original along with our new integer ~x~ field and the float ~y~ field.
+
+The same syntax can be used to replace a member.  If we wanted to replace ~x~ in the example ~a_new_record~ above, here's how we'd do it:
+#+BEGIN_SRC
+{x=5 | a_new_record}
+#+END_SRC
+
+What happens if we change the type of a field?
+#+BEGIN_SRC
+-- {x: int, y: int}
+let rec1 = {x=1, y=2}
+
+-- {x: string, y: int}
+let rec2 = {x="hello!", y=2}
+#+END_SRC
+
+Remember that updating a record actually makes an entirely new one so we allow for members to change type since it's not *actually* a mutation anyhow.
+
+There are currently no plans to enable the removal of record fields.
+
 **** What's Row Polymorphism?
 The key thing we're after from row polymorphism is not losing information.  For example in Java if we had the following:
 #+BEGIN_SRC
@@ -231,15 +257,8 @@ let identity my_rec =
 The return of ~identity({x=1, hello="world"})~ above is still the type ~{x: int, hello: string}~ in Alpaca  even though the function ~identity~ only cares about the field ~x: int~.
 
 **** What's Missing?
-There's not yet a way to access individual fields of a record without pattern matching (e.g. ~let my_rec = {x=1, hello="world"} in x.x~) nor is there a way to modify a record by making a copy with new or replaced fields.  The syntax currently under consideration:
-#+BEGIN_SRC
--- add an integer field named z to a record with x and y:
-let xy = {x=1, y=2} in
-{xy | z=3}
-#+END_SRC
-We should be able to use the above to both "update" fields in a record and also to extend a record with new fields.
+There's not yet a way to access individual fields of a record without pattern matching (e.g. ~let my_rec = {x=1, hello="world"} in x.x~)
 
-There are currently no plans to enable the removal of record fields.
 *** PIDs
 Process identifiers (references to processes to which we can send messages) are typed with the kind of messages they are able to receive.  The type of process that only knows how to receive strings can be expressed as ~pid string~.  We'll cover processes and PIDs in a bit more detail later but if you're unfamiliar with them from Erlang, [[http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency][The Hitchhiker's Guide to Concurrency]] from Learn You Some Erlang is a great place to start.
 * Functions

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -411,4 +411,14 @@ throw_with_variables_test() ->
     ?assertThrow({not_equal, 1, 2}, M:assert_equal(1, 2)),
     code:delete(M).
 
+record_update_test() ->
+    Files = ["test_files/update_record.alp",
+             "test_files/use_update_record.alp"],
+    [M1, M2] = compile_and_load(Files, []),
+
+    ?assertEqual(#{'__struct__' => record, x => 5}, M2:main(unit)),
+
+    code:delete(M1),
+    code:delete(M2).
+
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -169,7 +169,7 @@ type_import_test() ->
     ModuleNames = compile_and_load(Files, []),
     io:format("Compiled and loaded modules are ~w~n", [ModuleNames]),
     M = alpaca_type_import,
-    ?assertEqual(2, M:test_output(unit)),
+    ?assertEqual(2, M:test_output({})),
     [code:delete(N) || N <- ModuleNames].
 
 type_imports_and_pattern_test() ->
@@ -210,11 +210,11 @@ basic_pid_test() ->
 basic_map_test() ->
     Files =["test_files/basic_map_test.alp"],
     [M] = compile_and_load(Files, []),
-    ?assertEqual({'Ok', 1}, M:get('one', M:test_map(unit))),
-    ?assertEqual('NotFound', M:get('four', M:test_map(unit))),
+    ?assertEqual({'Ok', 1}, M:get('one', M:test_map({}))),
+    ?assertEqual('NotFound', M:get('four', M:test_map({}))),
 
-    ?assertEqual({'Ok', <<"b">>}, M:get({'two', 2}, M:test_tuple_key_map(unit))),
-    ?assertEqual('NotFound', M:get({'one', 2}, M:test_tuple_key_map(unit))),
+    ?assertEqual({'Ok', <<"b">>}, M:get({'two', 2}, M:test_tuple_key_map({}))),
+    ?assertEqual('NotFound', M:get({'one', 2}, M:test_tuple_key_map({}))),
     ?assertEqual(#{one => 1, two => 2}, M:add(one, 1, #{two => 2})),
 
     code:delete(M).
@@ -229,7 +229,7 @@ basic_binary_test() ->
     ?assertEqual(1, M:first_three_bits(<<2#00100000>>)),
     ?assertEqual(3, M:first_three_bits(<<2#01100000>>)),
 
-    ?assertEqual(<<"안녕"/utf8>>, M:utf8_bins(unit)),
+    ?assertEqual(<<"안녕"/utf8>>, M:utf8_bins({})),
 
     ?assertEqual(<<" world">>, M:drop_hello(<<"hello world">>)),
 
@@ -313,9 +313,9 @@ record_vs_map_match_order_test() ->
     
 raise_errors_test() ->
     [M] = compile_and_load(["test_files/error_tests.alp"], []),
-    ?assertException(throw, <<"this should be a throw">>, M:raise_throw(unit)),
-    ?assertException(exit, <<"exit here">>, M:raise_exit(unit)),
-    ?assertException(error, <<"and an error">>, M:raise_error(unit)),
+    ?assertException(throw, <<"this should be a throw">>, M:raise_throw({})),
+    ?assertException(exit, <<"exit here">>, M:raise_exit({})),
+    ?assertException(error, <<"and an error">>, M:raise_error({})),
 
     ?assertException(throw, <<"oh no zero!">>, M:throw_or_int(0)),
     ?assertEqual(4, M:throw_or_int(2)),
@@ -347,7 +347,7 @@ radius_test() ->
             ["test_files/radius.alp", 
              "test_files/use_radius.alp"], 
             []),
-    ?assertEqual(1, M2:test_radius(unit)),
+    ?assertEqual(1, M2:test_radius({})),
     code:delete(M1),
     code:delete(M2).
 
@@ -358,7 +358,7 @@ allow_duplicate_definition_with_different_arity_test() ->
 
 apply_to_expressions_test() ->
     [M] = compile_and_load(["test_files/apply_to_expression.alp"], []),
-    ?assertEqual(4, M:foo(unit)),
+    ?assertEqual(4, M:foo({})),
     ?assertEqual(6, M:uses_fun(3)),
     code:delete(M).
 
@@ -394,13 +394,13 @@ function_in_adt_test() ->
 
 curry_test() ->
     [M] = compile_and_load(["test_files/curry.alp"], []),
-    ?assertEqual({16,26,[2]}, M:foo(unit)),
+    ?assertEqual({16,26,[2]}, M:foo({})),
     code:delete(M).
 
 curry_import_export_test() ->
     Files = ["test_files/curry.alp", "test_files/curry_import.alp"],
     [M1, M2] = compile_and_load(Files, []),
-    ?assertEqual([3], M2:run_filter(unit)),
+    ?assertEqual([3], M2:run_filter({})),
     code:delete(M1),
     code:delete(M2).
 
@@ -416,18 +416,18 @@ record_update_test() ->
              "test_files/use_update_record.alp"],
     [M1, M2] = compile_and_load(Files, []),
 
-    ?assertEqual(#{'__struct__' => record, x => 5, b => 2}, M2:main(unit)),
-    ?assertEqual(#{'__struct__' => record, x => 2}, M2:overwrite_x(unit)),
+    ?assertEqual(#{'__struct__' => record, x => 5, b => 2}, M2:main({})),
+    ?assertEqual(#{'__struct__' => record, x => 2}, M2:overwrite_x({})),
     ?assertEqual(#{'__struct__' => record,
                    a => 1,
                    b => 2,
-                   c => 3}, M2:add_2_members(unit)),
+                   c => 3}, M2:add_2_members({})),
     ?assertEqual(#{'__struct__' => record,
                    a => 1,
                    b => 2,
                    c => 3,
                    x => 1.0,
-                   z => <<"this is z">>}, M2:add_3_members(unit)),
+                   z => <<"this is z">>}, M2:add_3_members({})),
     code:delete(M1),
     code:delete(M2).
 

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -416,7 +416,8 @@ record_update_test() ->
              "test_files/use_update_record.alp"],
     [M1, M2] = compile_and_load(Files, []),
 
-    ?assertEqual(#{'__struct__' => record, x => 5}, M2:main(unit)),
+    ?assertEqual(#{'__struct__' => record, x => 5, b => 2}, M2:main(unit)),
+    ?assertEqual(#{'__struct__' => record, x => 2}, M2:overwrite_x(unit)),
 
     code:delete(M1),
     code:delete(M2).

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -418,7 +418,16 @@ record_update_test() ->
 
     ?assertEqual(#{'__struct__' => record, x => 5, b => 2}, M2:main(unit)),
     ?assertEqual(#{'__struct__' => record, x => 2}, M2:overwrite_x(unit)),
-
+    ?assertEqual(#{'__struct__' => record,
+                   a => 1,
+                   b => 2,
+                   c => 3}, M2:add_2_members(unit)),
+    ?assertEqual(#{'__struct__' => record,
+                   a => 1,
+                   b => 2,
+                   c => 3,
+                   x => 1.0,
+                   z => <<"this is z">>}, M2:add_3_members(unit)),
     code:delete(M1),
     code:delete(M2).
 

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -304,6 +304,11 @@
                       members=[] :: list(alpaca_record_member())}).
 -type alpaca_record() :: #alpaca_record{}.
 
+-record(alpaca_record_update, {
+          line=-1 :: integer(),
+          additions=[] :: list(alpaca_record_member()),
+          existing :: alpaca_value_expression()}).
+-type alpaca_record_update() :: #alpaca_record_update{}.
 
 %%% Pattern Matching
 
@@ -390,6 +395,7 @@
                                | alpaca_map()
                                | alpaca_map_add()
                                | alpaca_record()
+                               | alpaca_record_update()
                                | alpaca_tuple()
                                | alpaca_apply()
                                | alpaca_type_apply()

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -307,11 +307,11 @@
                       members=[] :: list(alpaca_record_member())}).
 -type alpaca_record() :: #alpaca_record{}.
 
--record(alpaca_record_update, {
+-record(alpaca_record_transform, {
           line=-1 :: integer(),
           additions=[] :: list(alpaca_record_member()),
           existing :: alpaca_value_expression()}).
--type alpaca_record_update() :: #alpaca_record_update{}.
+-type alpaca_record_transform() :: #alpaca_record_transform{}.
 
 %%% Pattern Matching
 
@@ -398,7 +398,7 @@
                                | alpaca_map()
                                | alpaca_map_add()
                                | alpaca_record()
-                               | alpaca_record_update()
+                               | alpaca_record_transform()
                                | alpaca_tuple()
                                | alpaca_apply()
                                | alpaca_type_apply()

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -187,12 +187,15 @@
 %%%
 %%% These will do double-duty for both defining record types for ADTs
 %%% as well as to type records as they occur.
--record(t_record_member, {name=undefined :: atom(),
-                          type=undefined :: typ()}).
+-record(t_record_member, {
+          name=undefined :: atom(),
+          type=undefined :: typ()}).
 -type t_record_member() :: #t_record_member{}.
 
--record(t_record, {members=[] :: list(t_record_member()),
-                           row_var=undefined :: typ()}).
+-record(t_record, {
+          is_pattern=false :: boolean(),
+          members=[] :: list(t_record_member()),
+          row_var=undefined :: typ()}).
 
 -type t_record() :: #t_record{}.
 

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -563,6 +563,13 @@ rename_bindings(Env, Map, #alpaca_record{members=Members}=R) ->
     {NewMembers, Env2, Map2} = lists:foldl(F, {[], Env, Map}, Members),
     {Env2, Map2, R#alpaca_record{members=lists:reverse(NewMembers)}};
 
+rename_bindings(Env, Map, #alpaca_record_update{}=Update) ->
+    #alpaca_record_update{additions=As, existing=E} = Update,
+    FakeRec = #alpaca_record{members=As},
+    {Env2, Map2, #alpaca_record{members=Renamed}} = rename_bindings(Env, Map, FakeRec),
+    {Env3, Map3, E2} = rename_bindings(Env2, Map2, E),
+    {Env, Map3, #alpaca_record_update{additions=Renamed, existing=E2}};
+
 rename_bindings(Env, Map, {symbol, L, N}=S) ->
     case maps:get(N, Map, undefined) of
         undefined ->

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -563,12 +563,12 @@ rename_bindings(Env, Map, #alpaca_record{members=Members}=R) ->
     {NewMembers, Env2, Map2} = lists:foldl(F, {[], Env, Map}, Members),
     {Env2, Map2, R#alpaca_record{members=lists:reverse(NewMembers)}};
 
-rename_bindings(Env, Map, #alpaca_record_update{}=Update) ->
-    #alpaca_record_update{additions=As, existing=E} = Update,
+rename_bindings(Env, Map, #alpaca_record_transform{}=Update) ->
+    #alpaca_record_transform{additions=As, existing=E} = Update,
     FakeRec = #alpaca_record{members=As},
     {Env2, Map2, #alpaca_record{members=Renamed}} = rename_bindings(Env, Map, FakeRec),
     {Env3, Map3, E2} = rename_bindings(Env2, Map2, E),
-    {Env3, Map3, #alpaca_record_update{additions=Renamed, existing=E2}};
+    {Env3, Map3, #alpaca_record_transform{additions=Renamed, existing=E2}};
 
 rename_bindings(Env, Map, {symbol, L, N}=S) ->
     case maps:get(N, Map, undefined) of

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -361,7 +361,7 @@ next_batch([Token|Tail], Memo) ->
 
 -spec rename_bindings(
         Env::#env{},
-        TopLevel::alpaca_fun_def()) -> {integer(), map(), alpaca_fun_def()}.
+        TopLevel::alpaca_fun_def()) -> {#env{}, map(), alpaca_fun_def()}.
 rename_bindings(Environment, #alpaca_fun_def{}=TopLevel) ->
     #alpaca_fun_def{name={symbol, _, _}, versions=Vs}=TopLevel,
 
@@ -568,7 +568,7 @@ rename_bindings(Env, Map, #alpaca_record_update{}=Update) ->
     FakeRec = #alpaca_record{members=As},
     {Env2, Map2, #alpaca_record{members=Renamed}} = rename_bindings(Env, Map, FakeRec),
     {Env3, Map3, E2} = rename_bindings(Env2, Map2, E),
-    {Env, Map3, #alpaca_record_update{additions=Renamed, existing=E2}};
+    {Env3, Map3, #alpaca_record_update{additions=Renamed, existing=E2}};
 
 rename_bindings(Env, Map, {symbol, L, N}=S) ->
     case maps:get(N, Map, undefined) of

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -267,9 +267,10 @@ gen_expr(Env, #alpaca_record_update{additions=Adds, existing=Existing}) ->
                                    key={atom, L, atom_to_list(N)},
                                    val=V},
                          existing=RExp},
-                gen_expr(E, Add)
+                {E, Add}
         end,
-    {Env2, RecExp} = lists:foldl(F, {Env, Existing}, Adds),
+    {Env2, RecAst} = lists:foldl(F, {Env, Existing}, Adds),
+    {_, RecExp} = gen_expr(Env2, RecAst),
 
     %% Generating the update as a sequence of map additions re-labels the
     %% structure as a map, here we're just moving it back to a record.

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -260,7 +260,7 @@ gen_expr(Env, #alpaca_map_pair{key=K, val=V}) ->
 gen_expr(Env, #alpaca_record{}=R) ->
     {_, RExp} = gen_expr(Env, record_to_map(R)),
     {Env, RExp};
-gen_expr(Env, #alpaca_record_update{additions=Adds, existing=Existing}) ->
+gen_expr(Env, #alpaca_record_transform{additions=Adds, existing=Existing}) ->
     F = fun(#alpaca_record_member{line=L, name=N, val=V}, {E, RExp}) ->
                 Add = #alpaca_map_add{
                          to_add=#alpaca_map_pair{

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -260,6 +260,27 @@ gen_expr(Env, #alpaca_map_pair{key=K, val=V}) ->
 gen_expr(Env, #alpaca_record{}=R) ->
     {_, RExp} = gen_expr(Env, record_to_map(R)),
     {Env, RExp};
+gen_expr(Env, #alpaca_record_update{additions=Adds, existing=Existing}) ->
+    {Env2, EExp} = gen_expr(Env, Existing),
+    F = fun(#alpaca_record_member{line=L, name=N, val=V}, {E, RExp}) ->
+                Add = #alpaca_map_add{
+                         to_add=#alpaca_map_pair{
+                                   key={atom, L, atom_to_list(N)},
+                                   val=V}},
+                gen_expr(E, Add)
+        end,
+    {Env3, RecExp} = lists:foldl(F, {Env2, EExp}, Adds),
+
+    %% Generating the update as a sequence of map additions re-labels the
+    %% structure as a map, here we're just moving it back to a record.
+    {_, KExp} = gen_expr(Env3, {atom, 0, "__struct__"}),
+    {_, VExp} = gen_expr(Env, {atom, 0, "record"}),
+
+    {Env3, cerl:c_call(
+             cerl:c_atom(maps),
+             cerl:c_atom(put),
+             [KExp, VExp, RecExp])};
+
 gen_expr(Env, #alpaca_type_check{type=is_string, expr={symbol, _, _}=S}) ->
     {_, Exp} = gen_expr(Env, S),
     TC = cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom('is_binary'), [Exp]),

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -30,7 +30,7 @@ binary bin_segments bin_segment bin_qualifier bin_qualifiers
 map_literal map_add map_literal_pairs map_pair
 
 %% For literal records:
-record_member record_members record record_update
+record_member record_members record record_transform
 %% For pre-defined record types:
 record_type_member record_type_members record_type
 
@@ -397,9 +397,9 @@ record -> open_brace record_members close_brace:
   {_, L} = '$1',
   #alpaca_record{line=L, arity=length('$2'), members='$2'}.
 
-record_update -> open_brace record_members '|' term close_brace:
+record_transform -> open_brace record_members '|' term close_brace:
   {_, L} = '$1',
-  #alpaca_record_update{line=L, additions='$2', existing='$4'}.
+  #alpaca_record_transform{line=L, additions='$2', existing='$4'}.
 
 %% Need to permit "empty" records for pattern matches:
 record -> open_brace close_brace:
@@ -431,7 +431,7 @@ term -> binary : '$1'.
 term -> map_literal : '$1'.
 term -> map_add : '$1'.
 term -> record : '$1'.
-term -> record_update : '$1'.
+term -> record_transform : '$1'.
 term -> module_fun : '$1'.
 term -> '(' simple_expr ')' : '$2'.
 term -> type_apply : '$1'.
@@ -760,7 +760,7 @@ term_line(Term) ->
         #alpaca_map_pair{line=L} -> L;
         #alpaca_map{line=L} -> L;
         #alpaca_record{members=[#alpaca_record_member{line=L}|_]} -> L;
-        #alpaca_record_update{line=L} -> L;
+        #alpaca_record_transform{line=L} -> L;
         #alpaca_tuple{values=[H|_]} -> term_line(H);
         #alpaca_type_apply{name=N} -> term_line(N);
         #type_constructor{line=L} -> L

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -30,7 +30,7 @@ binary bin_segments bin_segment bin_qualifier bin_qualifiers
 map_literal map_add map_literal_pairs map_pair
 
 %% For literal records:
-record_member record_members record
+record_member record_members record record_update
 %% For pre-defined record types:
 record_type_member record_type_members record_type
 
@@ -397,6 +397,10 @@ record -> open_brace record_members close_brace:
   {_, L} = '$1',
   #alpaca_record{line=L, arity=length('$2'), members='$2'}.
 
+record_update -> open_brace record_members '|' term close_brace:
+  {_, L} = '$1',
+  #alpaca_record_update{line=L, additions='$2', existing='$4'}.
+
 %% Need to permit "empty" records for pattern matches:
 record -> open_brace close_brace:
   {_, L} = '$1',
@@ -427,6 +431,7 @@ term -> binary : '$1'.
 term -> map_literal : '$1'.
 term -> map_add : '$1'.
 term -> record : '$1'.
+term -> record_update : '$1'.
 term -> module_fun : '$1'.
 term -> '(' simple_expr ')' : '$2'.
 term -> type_apply : '$1'.
@@ -755,6 +760,7 @@ term_line(Term) ->
         #alpaca_map_pair{line=L} -> L;
         #alpaca_map{line=L} -> L;
         #alpaca_record{members=[#alpaca_record_member{line=L}|_]} -> L;
+        #alpaca_record_update{line=L} -> L;
         #alpaca_tuple{values=[H|_]} -> term_line(H);
         #alpaca_type_apply{name=N} -> term_line(N);
         #type_constructor{line=L} -> L

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1068,8 +1068,6 @@ inst_type_arrow(EnvIn, #type_constructor{}=TC) ->
                     Default = {error, {bad_constructor, Line, Name}},
                     %% constructors defined in this module or imported by it:
                     Available = EnvIn#env.type_constructors,
-                    io:format("Get constructor for ~s~n", [Name]),
-                    io:format("Available are ~w~n", [Available]),
                     proplists:get_value(Name, Available, Default);
 
                %% and the part where we go to a different module:
@@ -1713,7 +1711,7 @@ typ_of(Env, Lvl, #alpaca_record{is_pattern=IsPattern, members=Members}) ->
                       row_var=RowVar}),
     {Res, Env3#env.next_var};
 
-typ_of(Env, Lvl, #alpaca_record_update{additions=Adds, existing=Exists}) ->
+typ_of(Env, Lvl, #alpaca_record_transform{additions=Adds, existing=Exists}) ->
     {ExistsType, NV} = case typ_of(Env, Lvl, Exists) of
                            {error, _}=Err -> throw(Err);
                            OK -> OK
@@ -5101,7 +5099,7 @@ error_on_missing_types_test_() ->
       end
     ].
 
-record_update_test_() ->
+record_transform_test_() ->
     [?_assertMatch({#t_record{members=[#t_record_member{
                                           name=a,
                                           type=t_int},

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -865,7 +865,6 @@ flatten_record(#t_record{members=Ms, row_var=#t_record{}=Inner}) ->
     RecMems = [#t_record_member{name=N, type=T} || {N, T} <- maps:to_list(Deduped)],
     Rec = #t_record{members=RecMems, row_var=InnerRow},
     flatten_record(Rec);
-%    flatten_record(#t_record{members=Ms ++ InnerMs, row_var=InnerRow});
 flatten_record(#t_record{row_var=P}=R) when is_pid(P) ->
     case get_cell(P) of
         #t_record{}=Inner -> flatten_record(R#t_record{row_var=Inner});

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -788,12 +788,12 @@ unify_records(LowerBound, Target, Env, Line) ->
     %% or not the type is for a pattern because if we _are_ unifying for
     %% patterns then we don't need to check for missing members.
     #t_record{
-       is_pattern=P1, 
-       members=LowerM, 
+       is_pattern=P1,
+       members=LowerM,
        row_var=LowerRow} = flatten_record(LowerBound),
     #t_record{
-       is_pattern=P2, 
-       members=TargetM, 
+       is_pattern=P2,
+       members=TargetM,
        row_var=TargetRow} = flatten_record(Target),
 
     case TargetM of

--- a/test_files/update_record.alp
+++ b/test_files/update_record.alp
@@ -1,0 +1,5 @@
+module update_record
+
+export adds_x
+
+let adds_x x_val rec = {x=x_val | rec}

--- a/test_files/use_update_record.alp
+++ b/test_files/use_update_record.alp
@@ -1,0 +1,5 @@
+module use_update_record
+
+export main
+
+let main () = update_record.adds_x 5 {b=2}

--- a/test_files/use_update_record.alp
+++ b/test_files/use_update_record.alp
@@ -1,5 +1,6 @@
 module use_update_record
 
-export main
+export main, overwrite_x
 
 let main () = update_record.adds_x 5 {b=2}
+let overwrite_x () = update_record.adds_x 2 {x=3.0}

--- a/test_files/use_update_record.alp
+++ b/test_files/use_update_record.alp
@@ -1,6 +1,8 @@
 module use_update_record
 
-export main, overwrite_x
+export main, overwrite_x, add_2_members, add_3_members
 
 let main () = update_record.adds_x 5 {b=2}
 let overwrite_x () = update_record.adds_x 2 {x=3.0}
+let add_2_members () = {a=1, b=2 | {c=3}}
+let add_3_members () = {a=1, b=2, c=3 | {x=1.0, z="this is z"}}


### PR DESCRIPTION
Fixes #45 

Pretty basic syntax to add or update a field, e.g to add an `x: int` field to an existing record:

    {x=1 | existing_record}

Since record updates are non-destructive and thus not (strictly speaking) updates, I've allowed for members' types to change, e.g. the following is legal:

    -- results in {x: int, y: int}
    {x=1 | {x=1.0, y=5}}

I think this makes sense both because our updates are non-destructive and since we allow for records to be declared anywhere as literals without them specified as types prior.  This PR includes a test showing information loss when using type constructors for which I'll file a new issue.  I'm not entirely certain it's something we want to consider a real problem but I'll leave it for discussion in the issue itself once filed.