### PR TITLE
Make `map` not a reserved word

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -431,4 +431,12 @@ record_update_test() ->
     code:delete(M1),
     code:delete(M2).
 
+option_map_test() ->
+    Files = ["test_files/option_example.alp"],
+    [M] = compile_and_load(Files, []),
+    ?assertEqual({'Some', 1}, M:some(1)),
+    ?assertEqual({'Some', 2}, M:map(fun(X) -> X + 1 end, M:some(1))),
+    ?assertEqual('None', M:map(fun(X) -> X + 1 end, 'None')),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -31,7 +31,6 @@ TYPE_CHECK = is_integer|is_float|is_atom|is_bool|is_list|is_string|is_chars|is_p
 
 BASE_TYPE = atom|int|float|string|bool|binary|chars
 BASE_LIST = list
-BASE_MAP = map
 BASE_PID = pid
 
 Rules.
@@ -77,7 +76,6 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 %% Base types are the fundamental types available on the Erlang VM.
 {BASE_TYPE} : {token, {base_type, TokenLine, TokenChars}}.
 {BASE_LIST} : {token, {base_list, TokenLine}}.
-{BASE_MAP}  : {token, {base_map, TokenLine}}.
 {BASE_PID}  : {token, {base_pid, TokenLine}}.
 
 %% Type variables (nicked from OCaml):

--- a/test_files/option_example.alp
+++ b/test_files/option_example.alp
@@ -1,0 +1,12 @@
+module option_example
+
+export_type option
+
+export some, map
+
+type option 'a = Some 'a | None
+
+let some x = Some x
+
+let map _ None = None
+let map f Some x = Some (f x)


### PR DESCRIPTION
This should be left open for data structures that are basically
functors, e.g. option, etc.