### PR TITLE
Minor fixes for tests

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -432,8 +432,10 @@ record_update_test() ->
     code:delete(M2).
 
 option_map_test() ->
-    Files = ["test_files/option_example.alp"],
-    [M] = compile_and_load(Files, []),
+    %% Including asserts now to check a bug found when experimenting for the
+    %% beginning of alpaca_lib:
+    Files = ["test_files/option_example.alp", "test_files/asserts.alp"],
+    [M, _] = compile_and_load(Files, [test]),
     ?assertEqual({'Some', 1}, M:some(1)),
     ?assertEqual({'Some', 2}, M:map(fun(X) -> X + 1 end, M:some(1))),
     ?assertEqual('None', M:map(fun(X) -> X + 1 end, 'None')),

--- a/test_files/option_example.alp
+++ b/test_files/option_example.alp
@@ -10,3 +10,12 @@ let some x = Some x
 
 let map _ None = None
 let map f Some x = Some (f x)
+
+let ident x = x
+
+test "mapping a Some 1 with identity should result in Some 1" =
+  asserts.assert_equal Some 1 (map ident Some 1)
+
+test "mapping a None with identity should result in None" =
+  let f x = x in
+  asserts.assert_equal (map f None) None


### PR DESCRIPTION
Tests were being typed without the top-level bindings of their modules
being available.  Made it pretty difficult to test a module's functions!

@lepoetemaudit I discovered this when I started playing around with some stuff for `alpaca_lib` so you'll want this too I expect.