### PR TITLE
Fixes arity of generated curries

### DIFF
--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -338,7 +338,7 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
                lists:seq(DesiredArity+1, Arity)),
            CurryExpr = #alpaca_fun_def{
                              name={symbol, L, CurryFunName},
-                             arity=DesiredArity,
+                             arity=Arity-DesiredArity,
                              versions=[#alpaca_fun_version{
                                           args=CArgs,
                                           body=#alpaca_apply{

--- a/test_files/curry.alp
+++ b/test_files/curry.alp
@@ -6,10 +6,13 @@ export (|>)
 
 let (|>) x f = f x
 
+let many_args x y z o =
+  x + y + z + o
+
 let non_curry x =
   x + x
 
-let add x y = 
+let add x y =
   x + y
 
 let whatever i a =
@@ -29,11 +32,13 @@ let filter pred l =
 let eq a b =
   a == b
 
-let filtered_list () =    
+let filtered_list () =
   [1, 2, 3]
   |> filter (eq 2)
 
 let foo () =
+  let many_args_curry = many_args 1 in
+  let unused_curry = many_args_curry 2 4 1 in
   let adder = add 6 in
   (whatever 6 "yeh" |> add 5 |> add 5, adder 20, filtered_list ())
 


### PR DESCRIPTION
In some cases, codegen would fail as the arity of the generated function was not correctly calculated. For example, `let f x y z = x + y + z;; let main () = let curry = f 10 in curry 20 30` would run into this.

Sorry for not spotting this before, looks my tests weren't exhaustive enough.