### PR TITLE
Remove base types as reserved words.

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -18,7 +18,9 @@
 -type parse_error_reason() :: {module_rename, module(), module()} |
                               no_module |
                               {syntax_error, line(), string()} |
-                              {invalid_top_level_construct, term()} |
+                              {invalid_endianess, term()} |
+                              {invalid_bin_qualifier, string()} |
+                              {invalid_bin_type, string()} |
                               {wrong_type_arity, 't_list' | 't_map' | 't_pid',
                                non_neg_integer()}.
 
@@ -1685,6 +1687,23 @@ invalid_pid_type_parameters_test() ->
                  test_make_modules([Code1])),
     ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_pid, 2}}}},
                  test_make_modules([Code2])).
+
+invalid_base_type_parameters_test_() ->
+    Types = [ {"atom", t_atom},
+              {"binary", t_binary},
+              {"bool", t_bool},
+              {"chars", t_chars},
+              {"float", t_float},
+              {"int", t_int},
+              {"string", t_string}
+            ],
+    lists:map(fun({Token, Typ}) ->
+      Code = "module a\n\n"
+             "type concrete = Constructor\n"
+             "type x = " ++ Token ++ " concrete",
+      ?_assertMatch({error,{parse_error,_, {_,{wrong_type_arity,Typ, 1}}}},
+                   test_make_modules([Code]))
+    end, Types).
 
 test_make_modules(Sources) ->
     NamedSources = lists:map(fun(C) -> {?FILE, C} end, Sources),

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -19,7 +19,8 @@
                               no_module |
                               {syntax_error, line(), string()} |
                               {invalid_top_level_construct, term()} |
-                              {insufficient_params, string()}.
+                              {wrong_type_arity, 't_list' | 't_map' | 't_pid',
+                               non_neg_integer()}.
 
 -type module_validation_error() :: {module_validation_error, module(),
                                     module_validation_reason()}.
@@ -1658,11 +1659,11 @@ invalid_map_type_parameters_test() ->
             "type x = map int",
     Code3 = "module a\n\n"
             "type x = map int int int",
-    ?assertMatch({error,{parse_error,_, {_,{insufficient_params,"map"}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity,t_map, 0}}}},
                  test_make_modules([Code1])),
-    ?assertMatch({error,{parse_error,_, {_,{bad_map_params,[t_int]}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_map, 1}}}},
                  test_make_modules([Code2])),
-    ?assertMatch({error,{parse_error,_, {_,{bad_map_params,[t_int,t_int,t_int]}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_map, 3}}}},
                  test_make_modules([Code3])).
 
 invalid_list_type_parameters_test() ->
@@ -1670,9 +1671,9 @@ invalid_list_type_parameters_test() ->
             "type x = list",
     Code2 = "module a\n\n"
             "type x = list int int",
-    ?assertMatch({error,{parse_error,_, {_,{insufficient_params,"list"}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_list, 0}}}},
                  test_make_modules([Code1])),
-    ?assertMatch({error,{parse_error,_, {_,{bad_list_params,[t_int, t_int]}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_list, 2}}}},
                  test_make_modules([Code2])).
 
 invalid_pid_type_parameters_test() ->
@@ -1680,9 +1681,9 @@ invalid_pid_type_parameters_test() ->
             "type x = pid",
     Code2 = "module a\n\n"
             "type x = pid int int",
-    ?assertMatch({error,{parse_error,_, {_,{insufficient_params,"pid"}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity,t_pid, 0}}}},
                  test_make_modules([Code1])),
-    ?assertMatch({error,{parse_error,_, {_,{bad_pid_params,[t_int, t_int]}}}},
+    ?assertMatch({error,{parse_error,_, {_,{wrong_type_arity, t_pid, 2}}}},
                  test_make_modules([Code2])).
 
 test_make_modules(Sources) ->

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1675,6 +1675,16 @@ invalid_list_type_parameters_test() ->
     ?assertMatch({error,{parse_error,_, {_,{bad_list_params,[t_int, t_int]}}}},
                  test_make_modules([Code2])).
 
+invalid_pid_type_parameters_test() ->
+    Code1 = "module a\n\n"
+            "type x = pid",
+    Code2 = "module a\n\n"
+            "type x = pid int int",
+    ?assertMatch({error,{parse_error,_, {_,{insufficient_params,"pid"}}}},
+                 test_make_modules([Code1])),
+    ?assertMatch({error,{parse_error,_, {_,{bad_pid_params,[t_int, t_int]}}}},
+                 test_make_modules([Code2])).
+
 test_make_modules(Sources) ->
     NamedSources = lists:map(fun(C) -> {?FILE, C} end, Sources),
     make_modules(NamedSources).

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1665,6 +1665,16 @@ invalid_map_type_parameters_test() ->
     ?assertMatch({error,{parse_error,_, {_,{bad_map_params,[t_int,t_int,t_int]}}}},
                  test_make_modules([Code3])).
 
+invalid_list_type_parameters_test() ->
+    Code1 = "module a\n\n"
+            "type x = list",
+    Code2 = "module a\n\n"
+            "type x = list int int",
+    ?assertMatch({error,{parse_error,_, {_,{insufficient_params,"list"}}}},
+                 test_make_modules([Code1])),
+    ?assertMatch({error,{parse_error,_, {_,{bad_list_params,[t_int, t_int]}}}},
+                 test_make_modules([Code2])).
+
 test_make_modules(Sources) ->
     NamedSources = lists:map(fun(C) -> {?FILE, C} end, Sources),
     make_modules(NamedSources).

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -21,6 +21,7 @@
                               {invalid_endianess, term()} |
                               {invalid_bin_qualifier, string()} |
                               {invalid_bin_type, string()} |
+                              {invalid_fun_parameter, term()} |
                               {wrong_type_arity, 't_list' | 't_map' | 't_pid',
                                non_neg_integer()}.
 

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -65,7 +65,7 @@ comment_line comment_lines
 module export import
 import_type export_type
 
-type_declare type_constructor type_var base_type base_pid
+type_declare type_constructor type_var base_type
 
 test
 
@@ -143,6 +143,10 @@ poly_type -> symbol type_expressions :
           {t_map, K, V};
       {"map", Params} ->
           return_error(L, {bad_map_params, Params});
+      {"pid", [T]} ->
+          {t_pid, T};
+      {"pid", Params} ->
+          return_error(L, {bad_pid_params, Params});
       _ ->
           %% Any concrete type in the type_expressions gets a synthesized variable name:
           Vars = make_vars_for_concrete_types('$2', L),
@@ -200,6 +204,8 @@ sub_type_expr -> symbol :
           return_error(L, {insufficient_params, N});
       "map" ->
           return_error(L, {insufficient_params, N});
+      "pid" ->
+          return_error(L, {insufficient_params, N});
       _ ->
           #alpaca_type{name={type_name, L, N}, vars=[]} % not polymorphic
   end.
@@ -213,8 +219,6 @@ sub_type_expr -> base_type :
   {base_type, _, T} = '$1',
   list_to_atom("t_" ++ T).
 sub_type_expr -> unit : t_unit.
-sub_type_expr -> base_pid sub_type_expr :
-  {alpaca_pid, '$2'}.
 
 type_list -> comma_separated_type_list : '$1'.
 type_list -> type_expr: ['$1'].

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -691,7 +691,7 @@ make_infix(Op, A, B) ->
                   args=[A, B]}.
 
 make_define([{symbol, L, _} = Name|A], Expr, Level) ->
-    case validate_args(A) of
+    case validate_args(L, A) of
         {ok, []} ->
             %% If this is a zero-arg function, at the toplevel, it's a value
             %% and therefore its body must be restricted to literals only
@@ -724,19 +724,19 @@ make_define([BadName|Args], _Expr, _) ->
 %% Unit is only valid for single argument functions as a way around
 %% the problem of distinguishing between nullary functions and
 %% variable bindings in let forms:
-validate_args([{unit, _}]=Args) ->
+validate_args(_L, [{unit, _}]=Args) ->
     {ok, Args};
-validate_args(Args) ->
-    validate_args(Args, []).
+validate_args(L, Args) ->
+    validate_args(L, Args, []).
 
-validate_args([], GoodArgs) ->
+validate_args(_L, [], GoodArgs) ->
     {ok, lists:reverse(GoodArgs)};
-validate_args([#alpaca_match{}=E|_], _) ->
-    throw({invalid_fun_parameter, E});
-validate_args([#alpaca_spawn{}=E|_], _) ->
-    throw({invalid_fun_parameter, E});
-validate_args([A|T], Memo) ->
-    validate_args(T, [A|Memo]).
+validate_args(L, [#alpaca_match{}=E|_], _) ->
+    return_error(L, {invalid_fun_parameter, E});
+validate_args(L, [#alpaca_spawn{}=E|_], _) ->
+    return_error(L, {invalid_fun_parameter, E});
+validate_args(L, [A|T], Memo) ->
+    validate_args(L, T, [A|Memo]).
 
 %% Determine whether an expression is a literal
 is_literal({int, _, _}) -> true;

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -138,15 +138,15 @@ poly_type -> symbol type_expressions :
       {"list", [E]} ->
           {t_list, E};
       {"list", Params} ->
-          return_error(L, {bad_list_params, Params});
+          return_error(L, {wrong_type_arity, t_list, length(Params)});
       {"map", [K, V]} ->
           {t_map, K, V};
       {"map", Params} ->
-          return_error(L, {bad_map_params, Params});
+          return_error(L, {wrong_type_arity, t_map, length(Params)});
       {"pid", [T]} ->
           {t_pid, T};
       {"pid", Params} ->
-          return_error(L, {bad_pid_params, Params});
+          return_error(L, {wrong_type_arity, t_pid, length(Params)});
       _ ->
           %% Any concrete type in the type_expressions gets a synthesized variable name:
           Vars = make_vars_for_concrete_types('$2', L),
@@ -201,11 +201,11 @@ sub_type_expr -> symbol :
   {symbol, L, N} = '$1',
   case N of
       "list" ->
-          return_error(L, {insufficient_params, N});
+          return_error(L, {wrong_type_arity, t_list, 0});
       "map" ->
-          return_error(L, {insufficient_params, N});
+          return_error(L, {wrong_type_arity, t_map, 0});
       "pid" ->
-          return_error(L, {insufficient_params, N});
+          return_error(L, {wrong_type_arity, t_pid, 0});
       _ ->
           #alpaca_type{name={type_name, L, N}, vars=[]} % not polymorphic
   end.

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -65,7 +65,7 @@ comment_line comment_lines
 module export import
 import_type export_type
 
-type_declare type_constructor type_var base_type base_list base_pid
+type_declare type_constructor type_var base_type base_pid
 
 test
 
@@ -135,6 +135,10 @@ poly_type -> symbol type_expressions :
   Members = '$2',
 
   case {N, Members} of
+      {"list", [E]} ->
+          {t_list, E};
+      {"list", Params} ->
+          return_error(L, {bad_list_params, Params});
       {"map", [K, V]} ->
           {t_map, K, V};
       {"map", Params} ->
@@ -192,6 +196,8 @@ sub_type_expr -> record_type : '$1'.
 sub_type_expr -> symbol :
   {symbol, L, N} = '$1',
   case N of
+      "list" ->
+          return_error(L, {insufficient_params, N});
       "map" ->
           return_error(L, {insufficient_params, N});
       _ ->
@@ -207,8 +213,6 @@ sub_type_expr -> base_type :
   {base_type, _, T} = '$1',
   list_to_atom("t_" ++ T).
 sub_type_expr -> unit : t_unit.
-type_expr -> base_list sub_type_expr:
-  {t_list, '$2'}.
 sub_type_expr -> base_pid sub_type_expr :
   {alpaca_pid, '$2'}.
 

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -65,7 +65,7 @@ comment_line comment_lines
 module export import
 import_type export_type
 
-type_declare type_constructor type_var base_type
+type_declare type_constructor type_var
 
 test
 
@@ -135,18 +135,19 @@ poly_type -> symbol type_expressions :
   Members = '$2',
 
   case {N, Members} of
-      {"list", [E]} ->
-          {t_list, E};
-      {"list", Params} ->
-          return_error(L, {wrong_type_arity, t_list, length(Params)});
-      {"map", [K, V]} ->
-          {t_map, K, V};
-      {"map", Params} ->
-          return_error(L, {wrong_type_arity, t_map, length(Params)});
-      {"pid", [T]} ->
-          {t_pid, T};
-      {"pid", Params} ->
-          return_error(L, {wrong_type_arity, t_pid, length(Params)});
+      {"atom", Params}   -> type_arity_error(L, t_atom, Params);
+      {"binary", Params} -> type_arity_error(L, t_binary, Params);
+      {"bool", Params}   -> type_arity_error(L, t_bool, Params);
+      {"chars", Params}  -> type_arity_error(L, t_chars, Params);
+      {"float", Params}  -> type_arity_error(L, t_float, Params);
+      {"int", Params}    -> type_arity_error(L, t_int, Params);
+      {"list", [E]}      -> {t_list, E};
+      {"list", Params}   -> type_arity_error(L, t_list, Params);
+      {"map", [K, V]}    -> {t_map, K, V};
+      {"map", Params}    -> type_arity_error(L, t_map, Params);
+      {"pid", [T]}       -> {t_pid, T};
+      {"pid", Params}    -> type_arity_error(L, t_pid, Params);
+      {"string", Params} -> type_arity_error(L, t_string, Params);
       _ ->
           %% Any concrete type in the type_expressions gets a synthesized variable name:
           Vars = make_vars_for_concrete_types('$2', L),
@@ -200,12 +201,26 @@ sub_type_expr -> record_type : '$1'.
 sub_type_expr -> symbol :
   {symbol, L, N} = '$1',
   case N of
+      "atom" ->
+          t_atom;
+      "binary" ->
+          t_binary;
+      "bool" ->
+          t_bool;
+      "chars" ->
+          t_chars;
+      "float" ->
+          t_float;
+      "int" ->
+          t_int;
       "list" ->
           return_error(L, {wrong_type_arity, t_list, 0});
       "map" ->
           return_error(L, {wrong_type_arity, t_map, 0});
       "pid" ->
           return_error(L, {wrong_type_arity, t_pid, 0});
+      "string" ->
+          t_string;
       _ ->
           #alpaca_type{name={type_name, L, N}, vars=[]} % not polymorphic
   end.
@@ -215,9 +230,6 @@ sub_type_expr -> '(' type_expr ')': '$2'.
 sub_type_expr -> '[' type_list ']' '->' type_expr :
 
     {t_arrow, '$2', '$5'}.
-sub_type_expr -> base_type :
-  {base_type, _, T} = '$1',
-  list_to_atom("t_" ++ T).
 sub_type_expr -> unit : t_unit.
 
 type_list -> comma_separated_type_list : '$1'.
@@ -338,12 +350,14 @@ cons -> '[' literal_cons_items ']':
   lists:foldr(F, {nil, 0}, '$2').
 
 %% -----  Binaries  --------------------
-bin_qualifier -> type_declare assign base_type : '$3'.
 bin_qualifier -> type_declare assign symbol :
     {symbol, L, S} = '$3',
     case S of
-        "utf8" -> {bin_text_encoding, S};
-        _      -> return_error(L, {invalid_bin_text_encoding, S})
+        "binary" -> {bin_type, S};
+        "float" -> {bin_type, S};
+        "int" -> {bin_type, S};
+        "utf8" -> {bin_type, S};
+        _      -> return_error(L, {invalid_bin_type, S})
     end.
 bin_qualifier -> symbol assign int :
     {symbol, L, S} = '$1',
@@ -792,10 +806,7 @@ add_qualifier(#alpaca_bits{}=B, {unit, {int, _, I}}) ->
     B#alpaca_bits{unit=I, default_sizes=false};
 add_qualifier(#alpaca_bits{}=B, {bin_endian, _, E}) ->
     B#alpaca_bits{endian=list_to_atom(E)};
-add_qualifier(#alpaca_bits{}=B, {base_type, _, T})
-  when T =:= "int"; T =:= "float"; T =:= "binary"; T =:= "utf8" ->
-    B#alpaca_bits{type=list_to_atom(T)};
-add_qualifier(#alpaca_bits{}=B, {bin_text_encoding, Enc}) ->
+add_qualifier(#alpaca_bits{}=B, {bin_type, Enc}) ->
     B#alpaca_bits{type=list_to_atom(Enc)};
 add_qualifier(#alpaca_bits{}=B, {bin_sign, _, S}) ->
     B#alpaca_bits{sign=list_to_atom(S)}.
@@ -809,3 +820,7 @@ make_vars_for_concrete_types(Vars, Line) ->
         end,
     {Vs, _} = lists:foldl(F, {[], 0}, Vars),
     lists:reverse(Vs).
+
+type_arity_error(L, Typ, Params) ->
+    return_error(L, {wrong_type_arity, Typ, length(Params)}).
+

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -30,7 +30,6 @@ FLOAT_MATH = (\+\.)|(\-\.)|(\*\.)|(\/\.)
 TYPE_CHECK = is_integer|is_float|is_atom|is_bool|is_list|is_string|is_chars|is_pid|is_binary
 
 BASE_TYPE = atom|int|float|string|bool|binary|chars
-BASE_PID = pid
 
 Rules.
 %% Separators
@@ -74,7 +73,6 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Base types are the fundamental types available on the Erlang VM.
 {BASE_TYPE} : {token, {base_type, TokenLine, TokenChars}}.
-{BASE_PID}  : {token, {base_pid, TokenLine}}.
 
 %% Type variables (nicked from OCaml):
 '{SYM} : {token, {type_var, TokenLine, string:substr(TokenChars, 2)}}.

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -30,7 +30,6 @@ FLOAT_MATH = (\+\.)|(\-\.)|(\*\.)|(\/\.)
 TYPE_CHECK = is_integer|is_float|is_atom|is_bool|is_list|is_string|is_chars|is_pid|is_binary
 
 BASE_TYPE = atom|int|float|string|bool|binary|chars
-BASE_LIST = list
 BASE_PID = pid
 
 Rules.
@@ -75,7 +74,6 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Base types are the fundamental types available on the Erlang VM.
 {BASE_TYPE} : {token, {base_type, TokenLine, TokenChars}}.
-{BASE_LIST} : {token, {base_list, TokenLine}}.
 {BASE_PID}  : {token, {base_pid, TokenLine}}.
 
 %% Type variables (nicked from OCaml):

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -29,8 +29,6 @@ BRK = \n(\n)+
 FLOAT_MATH = (\+\.)|(\-\.)|(\*\.)|(\/\.)
 TYPE_CHECK = is_integer|is_float|is_atom|is_bool|is_list|is_string|is_chars|is_pid|is_binary
 
-BASE_TYPE = atom|int|float|string|bool|binary|chars
-
 Rules.
 %% Separators
 ,     : {token, {',', TokenLine}}.
@@ -70,9 +68,6 @@ test        : {token, {'test', TokenLine}}.
 error|exit|throw : {token, {'raise_error', TokenLine, TokenChars}}.
 
 true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
-
-%% Base types are the fundamental types available on the Erlang VM.
-{BASE_TYPE} : {token, {base_type, TokenLine, TokenChars}}.
 
 %% Type variables (nicked from OCaml):
 '{SYM} : {token, {type_var, TokenLine, string:substr(TokenChars, 2)}}.

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -133,7 +133,7 @@ infer_bin_test() ->
                        {'let', 2}, {symbol, 2, "a"}, {assign, 2}, 
                                    {bin_open, 2}, {int, 2, 10},
                                    {':', 2}, {type_declare, 2},
-                                   {assign, 2}, {base_type, 2, "int"},
+                                   {assign, 2}, {symbol, 2, "int"},
                                    {bin_close, 2}
                      ],                       
     ?assertEqual({ok, ExpectedTokens, 2}, scan(Code)).

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -960,7 +960,7 @@ inst_type_members(ADT, [#t_record{}=R|Rem], Env, Memo) ->
     NewT = new_cell(#t_record{members=lists:reverse(NewMems), row_var=RVC}),
     inst_type_members(ADT, Rem, Env3, [NewT|Memo]);
 
-inst_type_members(ADT, [{alpaca_pid, TExp}|Rem], Env, Memo) ->
+inst_type_members(ADT, [{t_pid, TExp}|Rem], Env, Memo) ->
     case inst_type_members(ADT, [TExp], Env, []) of
         {error, _}=Err ->
             Err;
@@ -1148,7 +1148,7 @@ inst_constructor_arg({t_map, KeyType, ValType}, Vs, Types, Env) ->
     {Env2, KElem} = inst_constructor_arg(KeyType, Vs, Types, Env),
     {Env3, VElem} = inst_constructor_arg(ValType, Vs, Types, Env2),
     {Env3, new_cell({t_map, KElem, VElem})};
-inst_constructor_arg({alpaca_pid, MsgType}, Vs, Types, Env) ->
+inst_constructor_arg({t_pid, MsgType}, Vs, Types, Env) ->
     {Env2, PidElem} = inst_constructor_arg(MsgType, Vs, Types, Env),
     {Env, new_cell({t_pid, PidElem})};
 inst_constructor_arg(#alpaca_type{name={type_name, _, N}, vars=Vars, members=M1},


### PR DESCRIPTION
This frees up the following to be used as identifiers in code:
* atom
* binary
* bool
* chars
* float
* list
* pid
* string