### PR TITLE
Provide file path and line number for all parse errors.

### DIFF
--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -163,7 +163,9 @@
                         | t_float
                         | t_string
                         | t_pid
-                        | t_bool.
+                        | t_bool
+                        | t_chars
+                        | t_unit.
 
 -type alpaca_type_name() :: {type_name, integer(), string()}.
 -type alpaca_type_var()  :: {type_var, integer(), string()}.
@@ -175,13 +177,19 @@
          }).
 -type alpaca_type_tuple() :: #alpaca_type_tuple{}.
 
+-type alpaca_list_type() :: {t_list, alpaca_base_type()|alpaca_poly_type()}.
+
 -type alpaca_map_type() :: {t_map,
                           alpaca_base_type()|alpaca_poly_type(),
                           alpaca_base_type()|alpaca_poly_type()}.
 
+-type alpaca_pid_type() :: {t_list, alpaca_base_type()|alpaca_poly_type()}.
+
 -type alpaca_poly_type() :: alpaca_type()
                         | alpaca_type_tuple()
-                        | alpaca_map_type().
+                        | alpaca_list_type()
+                        | alpaca_map_type()
+                        | alpaca_pid_type().
 
 %%% ### Record Type Tracking
 %%%
@@ -222,7 +230,9 @@
 -type alpaca_types() :: alpaca_type()
                     | alpaca_type_tuple()
                     | alpaca_base_type()
-                    | alpaca_map_type().
+                    | alpaca_list_type()
+                    | alpaca_map_type()
+                    | alpaca_pid_type().
 
 -record(alpaca_type, {
           line=0 :: integer(),
@@ -498,6 +508,7 @@
 %% original names.
 -record(alpaca_module, {
           name=no_module :: atom(),
+          filename=undefined :: string() | undefined,
           rename_map=maps:new() :: map(),
           function_exports=[] :: list({string(), integer()}|string()),
           function_imports=[] :: list({string(), {atom(), integer()}|string()}),

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -27,6 +27,7 @@
                         {invalid_bin_qualifier, string()} |
                         {invalid_bin_type, string()} |
                         {invalid_fun_parameter, term()} |
+                        {invalid_top_level_construct, term()} |
                         {module_rename, module(), module()} |
                         no_module |
                         {no_module, module()} |

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -294,10 +294,10 @@ unique_type_constructors(Mod, Types) ->
         {error, {N, L}} -> parse_error(Mod, L, {duplicate_constructor, N})
     end.
 
-update_memo(#alpaca_module{name=no_module}=Mod, {module, Name}) ->
+update_memo(#alpaca_module{name=no_module}=Mod, {module, Name, _}) ->
     Mod#alpaca_module{name=Name};
-update_memo(#alpaca_module{name=Name}=Mod, {module, DupeName}) ->
-    parse_error(Mod, 1, {module_rename, Name, DupeName});
+update_memo(#alpaca_module{name=Name}=Mod, {module, DupeName, L}) ->
+    parse_error(Mod, L, {module_rename, Name, DupeName});
 update_memo(#alpaca_module{type_imports=Imports}=M, #alpaca_type_import{}=I) ->
     M#alpaca_module{type_imports=Imports ++ [I]};
 update_memo(#alpaca_module{type_exports=Exports}=M, #alpaca_type_export{}=I) ->
@@ -1052,10 +1052,12 @@ application_test_() ->
     ].
 
 module_def_test_() ->
-    [?_assertMatch({ok, {module, 'test_mod'}},
+    [?_assertMatch({ok, {module, 'test_mod', 1}},
                    parse(alpaca_scanner:scan("module test_mod"))),
-     ?_assertMatch({ok, {module, 'myMod'}},
-                   parse(alpaca_scanner:scan("module myMod")))
+     ?_assertMatch({ok, {module, 'myMod', 1}},
+                   parse(alpaca_scanner:scan("module myMod"))),
+     ?_assertThrow({parse_error, ?FILE, 2, {module_rename, mod1, mod2}},
+                   parse_module({?FILE, "module mod1\nmodule mod2"}))
     ].
 
 export_test_() ->

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -125,8 +125,6 @@ type_export -> export_type types_to_export :
   Names = [N || {symbol, _, N} <- '$2'],
   #alpaca_type_export{line=L, names=Names}.
 
-module_def -> module atom : {module, '$1'}.
-
 type_expressions -> sub_type_expr : ['$1'].
 type_expressions -> sub_type_expr type_expressions : ['$1'|'$2'].
 
@@ -541,8 +539,8 @@ ffi_call -> beam atom atom cons with match_clauses:
             clauses='$6'}.
 
 module_def -> module symbol :
-{symbol, _, Name} = '$2',
-{module, list_to_atom(Name)}.
+{symbol, L, Name} = '$2',
+{module, list_to_atom(Name), L}.
 
 export_def -> export export_list : {export, '$2'}.
 %% Imported functions come out of the parser in the following tuple format:


### PR DESCRIPTION
This makes all errors from the parse and AST generation stages contain the file name/path and the line number the error pertains to.

There are two cases were line numbers are incorrectly reported (i.e. reported as 1) at the moment:
* `{invalid_top_level_construct, term()}`. We can hopefully remove this in the future by restructuring the grammar. Another alternative is to *consistently* specify the line numbers for all elements generated by the parser. Both of these refactorings are too big to include in this work.
* `{no_module, module()}` when an unknown module is specified in a type import. I tried this, but the required changes were a bit too invasive to be included at this time.