### PR TITLE
Lambdas and one kind of binding

### DIFF
--- a/Tour.md
+++ b/Tour.md
@@ -40,6 +40,7 @@
 <li><a href="#sec-4-1">4.1. The Foreign Function Interface</a></li>
 <li><a href="#sec-4-2">4.2. Built-In Functions</a></li>
 <li><a href="#sec-4-3">4.3. Currying</a></li>
+<li><a href="#sec-4-4">4.4. Lambdas</a></li>
 </ul>
 </li>
 <li><a href="#sec-5">5. User Defined Types:  ADTs</a></li>
@@ -442,6 +443,41 @@ Some examples:
     -- assuming a filter/2 function that takens a predicate function and a list 'a
     let filtered_list () =
       filter (eq 3) [1, 2, 3]
+
+## Lambdas<a id="sec-4-4" name="sec-4-4"></a>
+
+Lambdas (AKA anonymous functions) can be defined with the `fn` keyword:
+
+    fn x -> x + 1
+
+They can also be bound to variable names, e.g. these two versions of `double` will produce the exact same output binary:
+
+    let double = fn x -> x + x
+    
+    let double x = x + x
+
+We can also use lambdas as arguments to other functions, here's an example of passing a function that adds 1 to each element of an integer list:
+
+    let example () =
+      map (fn x -> x + 1) [1, 2, 3]
+    
+    test "example should result in [2, 3, 4]" =
+      assert_equal (example ()) [2, 3, 4]
+    
+    -- here's a simple definition of the map function:
+    let map f [] = []
+    let map f (h :: t) = (f h) :: (map f t)
+
+Finally, we can use the unicode lambda and right-arrow characters if we want to.  These two functions are identical:
+
+    λ x → x + 1
+    
+    fn x -> x + 1
+
+So the following would work the same as our `example` function above:
+
+    let example () =
+      map (λ x → x + 1) [1, 2, 3]
 
 # User Defined Types:  ADTs<a id="sec-5" name="sec-5"></a>
 

--- a/Tour.org
+++ b/Tour.org
@@ -379,6 +379,43 @@ let filtered_list () =
   filter (eq 3) [1, 2, 3]
 
 #+END_SRC
+
+** Lambdas
+Lambdas (AKA anonymous functions) can be defined with the ~fn~ keyword:
+#+BEGIN_SRC
+fn x -> x + 1
+#+END_SRC
+They can also be bound to variable names, e.g. these two versions of ~double~ will produce the exact same output binary:
+#+BEGIN_SRC
+let double = fn x -> x + x
+
+let double x = x + x
+#+END_SRC
+
+We can also use lambdas as arguments to other functions, here's an example of passing a function that adds 1 to each element of an integer list:
+#+BEGIN_SRC
+let example () =
+  map (fn x -> x + 1) [1, 2, 3]
+
+test "example should result in [2, 3, 4]" =
+  assert_equal (example ()) [2, 3, 4]
+
+-- here's a simple definition of the map function:
+let map f [] = []
+let map f (h :: t) = (f h) :: (map f t)
+#+END_SRC
+
+Finally, we can use the unicode lambda and right-arrow characters if we want to.  These two functions are identical:
+#+BEGIN_SRC
+λ x → x + 1
+
+fn x -> x + 1
+#+END_SRC
+So the following would work the same as our ~example~ function above:
+#+BEGIN_SRC
+let example () =
+  map (λ x → x + 1) [1, 2, 3]
+#+END_SRC
 * User Defined Types:  ADTs
 We can currently specify new types by combining existing ones, creating [[https://en.wikipedia.org/wiki/Algebraic_data_type][algebraic data types (ADTs)]].  These new types will also be inferred correctly, here's a simple example of a broad "number" type that combines integers and floats:
 

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -449,6 +449,7 @@ lambdas_test() ->
     ?assertEqual(2, M:no_sugar_top_binding(1)),
     ?assertEqual({'T', [2, 3, 4]}, M:map_to_make_t([1, 2, 3])),
     ?assertEqual([2, 3, 4], M:nested_fun({})),
+    ?assertEqual(4, M:use_lambda(3)),
     code:delete(M).
 
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -441,4 +441,12 @@ option_map_test() ->
     ?assertEqual('None', M:map(fun(X) -> X + 1 end, 'None')),
     code:delete(M).
 
+lambdas_test() ->
+    Files = ["test_files/lambda_examples.alp"],
+    [M] = compile_and_load(Files, []),
+    ?assertEqual([2, 3, 4], M:map_lambda({})),
+    ?assertEqual(3, M:no_sugar_internal_binding({})),
+    ?assertEqual(2, M:no_sugar_top_binding(1)),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -447,6 +447,7 @@ lambdas_test() ->
     ?assertEqual([2, 3, 4], M:map_lambda({})),
     ?assertEqual(3, M:no_sugar_internal_binding({})),
     ?assertEqual(2, M:no_sugar_top_binding(1)),
+    ?assertEqual({'T', [2, 3, 4]}, M:map_to_make_t([1, 2, 3])),
     code:delete(M).
 
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -448,6 +448,7 @@ lambdas_test() ->
     ?assertEqual(3, M:no_sugar_internal_binding({})),
     ?assertEqual(2, M:no_sugar_top_binding(1)),
     ?assertEqual({'T', [2, 3, 4]}, M:map_to_make_t([1, 2, 3])),
+    ?assertEqual([2, 3, 4], M:nested_fun({})),
     code:delete(M).
 
 -endif.

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -430,20 +430,6 @@
                          | alpaca_type_export()
                          | alpaca_error().
 
--record(fun_binding, {def :: alpaca_fun_def(),
-                      expr :: alpaca_expression()
-                     }).
-
--record(var_binding, {type=undefined :: typ(),
-                      name=undefined :: undefined|alpaca_symbol(),
-                      to_bind=undefined :: undefined|alpaca_expression(),
-                      expr=undefined :: undefined|alpaca_expression()
-                     }).
-
--type fun_binding() :: #fun_binding{}.
--type var_binding() :: #var_binding{}.
--type alpaca_binding() :: fun_binding()|var_binding().
-
 %% When calling BIFs like erlang:'+' it seems core erlang doesn't want
 %% the arity specified as part of the function name.  alpaca_bif_name()
 %% is a way to indicate what the ALPACA function name is and the corresponding
@@ -511,6 +497,7 @@
           bound_expr=undefined :: undefined | alpaca_expression(),
           body=undefined :: undefined | alpaca_expression()
          }).
+-type alpaca_binding() :: #alpaca_binding{}.
 
 -record (alpaca_fun_def, {
            type=undefined :: typ(),

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -415,6 +415,7 @@
                                | alpaca_match()
                                | alpaca_receive()
                                | alpaca_clause()
+                               | alpaca_fun()
                                | alpaca_spawn()
                                | alpaca_send()
                                | alpaca_ffi().
@@ -487,6 +488,24 @@
           body=undefined :: undefined|alpaca_expression()
          }).
 
+-record(alpaca_fun, {
+          line=0 :: integer(),
+          type=undefined :: typ(),
+          arity=0 :: integer(),
+          versions=[] :: list(#alpaca_fun_version{})
+         }).
+-type alpaca_fun() :: #alpaca_fun{}.
+
+%% `body` remains `undefined` for top-level expressions and otherwise for
+%% things like function and variable bindings within a top-level function.
+-record(alpaca_binding, {
+          line=0 :: integer(),
+          name=undefined :: undefined | alpaca_symbol(),
+          type=undefined :: typ(),
+          bound_expr=undefined :: undefined | alpaca_expression(),
+          body=undefined :: undefined | alpaca_expression()
+         }).
+
 -record (alpaca_fun_def, {
            type=undefined :: typ(),
            name=undefined :: undefined|alpaca_symbol(),
@@ -515,7 +534,7 @@
           types=[] :: list(alpaca_type()),
           type_imports=[] :: list(alpaca_type_import()),
           type_exports=[] :: list(string()),
-          functions=[] :: list(alpaca_fun_def()),
+          functions=[] :: list(alpaca_binding()),
           tests=[] :: list(alpaca_test())
          }).
 -type alpaca_module() :: #alpaca_module{}.

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -488,10 +488,16 @@
           body=undefined :: undefined|alpaca_expression()
          }).
 
+%% The name field in an #alpaca_fun{} is there for the typer's convenience.
+%% When typing an #alpaca_binding{}, the typer inserts the bound name into the
+%% function to enable "let rec" behaviour.  We could relax this later to allow
+%% for non-recursive let behaviour but I can't think of a good reason to go for
+%% that at the immediate moment.
 -record(alpaca_fun, {
           line=0 :: integer(),
           type=undefined :: typ(),
           arity=0 :: integer(),
+          name=undefined :: undefined | string(),
           versions=[] :: list(#alpaca_fun_version{})
          }).
 -type alpaca_fun() :: #alpaca_fun{}.

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1,7 +1,7 @@
 %%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %%% ex: ft=erlang ts=4 sw=4 et
 -module(alpaca_ast_gen).
--export([parse/1, make_modules/1]).
+-export([parse/1, make_modules/1, term_line/1]).
 
 %% Parse is used by other modules (particularly alpaca_typer) to make ASTs
 %% from code that does not necessarily include a module:
@@ -61,9 +61,10 @@
 make_modules(Code) ->
     try
       Modules = [parse_module(SourceCode) || SourceCode <- Code],
+      io:format("Modules parsed~n", []),
       {ok, rename_and_resolve(Modules)}
     catch
-      throw:{parse_error, _, _, _}=Err -> {error, Err}
+        throw:{parse_error, _, _, _}=Err -> {error, Err}
     end.
 
 parse_error(#alpaca_module{filename=FileName}, Line, Error) ->
@@ -132,16 +133,20 @@ rename_and_resolve(Modules) ->
 expand_exports(Modules) ->
     expand_exports(Modules, []).
 
+name_and_arity(#alpaca_binding{name={symbol, _, N}, bound_expr=E}) ->
+    case E of
+        #alpaca_fun{arity=A} -> {N, A};
+        _                    -> {N, 0}
+    end.
+
 expand_exports([], Memo) ->
     Memo;
 expand_exports([M|Tail], Memo) ->
     F = fun({_, _}=FunWithArity) -> 
                 FunWithArity;
            (Name) when is_list(Name) ->
-                [{Name, A} || #alpaca_fun_def{
-                                 name={symbol, _, N}, 
-                                 arity=A
-                                } <- M#alpaca_module.functions, N =:= Name]
+                NameAndArity = [name_and_arity(F) || F <- M#alpaca_module.functions],
+                [{Name, A} || {N, A} <- NameAndArity, N =:= Name]
         end,
     Exports = lists:flatten(lists:map(F, M#alpaca_module.function_exports)),
     expand_exports(Tail, [M#alpaca_module{function_exports=Exports}|Memo]).
@@ -181,11 +186,15 @@ expand_imports([M|Tail], ExportMap, Memo) ->
 group_funs(Funs, _ModuleName) ->
     OrderedKeys = 
         drop_dupes_preserve_order(
-          lists:map(
-            fun(#alpaca_fun_def{name={symbol, _, N}, arity=A}) -> {N, A} end,
-            lists:reverse(Funs)),
+          lists:map(fun name_and_arity/1, lists:reverse(Funs)),
           []),
-    F = fun(#alpaca_fun_def{name={symbol, _, N}, arity=A, versions=[V]}, Acc) ->
+    F = fun(#alpaca_binding{name={symbol, _, N}, bound_expr=Expr}, Acc) ->
+                {N, A, V} = case Expr of
+                                #alpaca_fun{arity=Arity, versions=[Ver]} ->
+                                    {N, Arity, Ver};
+                                _ ->
+                                    {N, 0, Expr}
+                         end,
                 Key = {N, A},
                 Existing = maps:get(Key, Acc, []),
                 maps:put(Key, [V|Existing], Acc)
@@ -194,12 +203,40 @@ group_funs(Funs, _ModuleName) ->
     lists:map(
       fun({N, A}=Key) -> 
               NewVs = lists:reverse(maps:get(Key, Grouped)),
-              [#alpaca_fun_version{line=L}|_] = NewVs,
+              [X|_] = NewVs,
+              L = term_line(X),
               %% we use the first occurence's line as the function's primary
               %% location:
-              #alpaca_fun_def{name={symbol, L, N}, arity=A, versions=NewVs}
+              case A of
+                  0 ->
+                      [OnlyV] = NewVs,
+                      #alpaca_binding{name={symbol, L, N}, bound_expr=OnlyV};
+                  _ ->
+                      #alpaca_binding{name={symbol, L, N}, 
+                                      bound_expr=#alpaca_fun{
+                                                    arity=A, 
+                                                    versions=NewVs}}
+              end
       end, 
       OrderedKeys).
+
+term_line(Term) ->
+    case Term of
+        {_, L} when is_integer(L) -> L;
+        {_, L, _} when is_integer(L) -> L;
+        {bif, _, L, _, _} -> L;
+        #alpaca_apply{line=L} -> L;
+        #alpaca_cons{line=L} -> L;
+        #alpaca_map_pair{line=L} -> L;
+        #alpaca_map{line=L} -> L;
+        #alpaca_record{members=[#alpaca_record_member{line=L}|_]} -> L;
+        #alpaca_record_transform{line=L} -> L;
+        #alpaca_tuple{values=[H|_]} -> term_line(H);
+        #alpaca_type_apply{name=N} -> term_line(N);
+        #alpaca_fun_version{line=L} -> L;
+        #type_constructor{line=L} -> L
+    end.
+
 
 drop_dupes_preserve_order([], Memo) ->
     lists:reverse(Memo);
@@ -233,13 +270,22 @@ rebind_and_validate_module(NextVarNum, #alpaca_module{}=Mod, Modules) ->
 %% All available modules required so that we can rewrite applications of
 %% functions not in Mod to inter-module calls.
 rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
+    io:format("Rebind and validate~n", []),
     #alpaca_module{name=_MN, functions=Funs}=Mod,
-    Bindings = [{N, A} || #alpaca_fun_def{name={_, _, N}, arity=A} <- Funs],
+    BindingF = fun(#alpaca_binding{name={_, _, N}, bound_expr=#alpaca_fun{arity=A}}) ->
+                       {N, A};
+                  (#alpaca_binding{name={_, _, N}}) ->
+                       {N, 0}
+               end,
+    Bindings = [BindingF(F) || F <- Funs],
+
     Env = #env{next_var=NextVarNum,
                rename_map=maps:new(),
                current_bindings=Bindings,
                current_module=Mod,
                modules=Modules},
+
+    io:format("Names and arities for rebinding and validating~n", []),
 
     F = fun(F, {E, Memo}) ->
                 {#env{next_var=NV2, rename_map=_M}, M2, F2} = rename_bindings(E, F),
@@ -308,7 +354,7 @@ update_memo(#alpaca_module{function_exports=Exports}=M, {export, Es}) ->
     M#alpaca_module{function_exports=Es ++ Exports};
 update_memo(#alpaca_module{function_imports=Imports}=M, {import, Is}) ->
     M#alpaca_module{function_imports=Imports ++ Is};
-update_memo(#alpaca_module{functions=Funs}=M, #alpaca_fun_def{} = Def) ->
+update_memo(#alpaca_module{functions=Funs}=M, #alpaca_binding{} = Def) ->
     M#alpaca_module{functions=[Def|Funs]};
 update_memo(#alpaca_module{types=Ts}=M, #alpaca_type{}=T) ->
     M#alpaca_module{types=[T|Ts]};
@@ -362,24 +408,30 @@ next_batch([Token|Tail], Memo) ->
 -spec rename_bindings(
         Env::#env{},
         TopLevel::alpaca_fun_def()) -> {#env{}, map(), alpaca_fun_def()}.
-rename_bindings(Environment, #alpaca_fun_def{}=TopLevel) ->
-    #alpaca_fun_def{name={symbol, _, _}, versions=Vs}=TopLevel,
-
-    F = fun(#alpaca_fun_version{args=As, body=Body}=FV, {Env, Map, Versions}) ->
-            {Env2, M2, Args} = make_bindings(Env, Map, As),
-            {Env3, _M3, E} =  rename_bindings(Env2, M2, Body),
-            FV2 = FV#alpaca_fun_version{
-                    args=Args,
-                    body=E},
-            %% As with patterns and clauses we deliberately
-            %% throw away the rename map here so that the
-            %% same symbols can be reused by distinctly
-            %% different function definitions.
-            {Env3, Map, [FV2|Versions]}
-        end,
-
-    {Env, M2, Vs2} = lists:foldl(F, {Environment, maps:new(), []}, Vs),
-    {Env, M2, TopLevel#alpaca_fun_def{versions=Vs2}}.
+rename_bindings(Environment, #alpaca_binding{}=TopLevel) ->
+    #alpaca_binding{name={symbol, _, _}, bound_expr=Expr} = TopLevel,
+    case Expr of
+        #alpaca_fun{versions=Vs} ->
+            F = fun(#alpaca_fun_version{args=As, body=Body}=FV, {Env, Map, Versions}) ->
+                        {Env2, M2, Args} = make_bindings(Env, Map, As),
+                        {Env3, _M3, E} =  rename_bindings(Env2, M2, Body),
+                        FV2 = FV#alpaca_fun_version{
+                                args=Args,
+                                body=E},
+                        %% As with patterns and clauses we deliberately
+                        %% throw away the rename map here so that the
+                        %% same symbols can be reused by distinctly
+                        %% different function definitions.
+                        {Env3, Map, [FV2|Versions]}
+                end,
+            
+            {Env, M2, Vs2} = lists:foldl(F, {Environment, maps:new(), []}, Vs),
+            {Env, M2, TopLevel#alpaca_binding{bound_expr=Expr#alpaca_fun{versions=Vs2}}};
+        _ ->
+            io:format("Rename top-level val~n", []),
+            {Env, _, E} =  rename_bindings(Environment, maps:new(), Expr),
+            {Env, maps:new(), TopLevel#alpaca_binding{bound_expr=E}}
+    end.
 
 rebind_args(#env{current_module=Mod}=Env, Map, Args) ->
     F = fun({symbol, L, N}, {#env{next_var=NV}=E, AccMap, Syms}) ->
@@ -401,14 +453,9 @@ rebind_args(#env{current_module=Mod}=Env, Map, Args) ->
     {Env2, M, Args2} = lists:foldl(F, {Env, Map, []}, Args),
     {Env2, M, lists:reverse(Args2)}.
 
-rename_bindings(Env, Map, #fun_binding{def=Def, expr=E}) ->
-    {Env2, M2, Def2} = rename_bindings(Env, Map, Def),
-    {Env3, M3, E2} = rename_bindings(Env2, M2, E),
-    {Env3, M3, #fun_binding{def=Def2, expr=E2}};
-
 rename_bindings(#env{current_module=Mod}=StartEnv, M,
-                #alpaca_fun_def{name={symbol, L, Name}}=Def) ->
-    #alpaca_fun_def{versions=Vs}=Def,
+                #alpaca_binding{name={symbol, L, Name}}=Binding) ->
+    #alpaca_binding{bound_expr=Expr, body=Body} = Binding,
     {NewName, En2, M2} = case maps:get(Name, M, undefined) of
                               undefined ->
                                   #env{next_var=NV} = StartEnv,
@@ -420,21 +467,36 @@ rename_bindings(#env{current_module=Mod}=StartEnv, M,
                           end,
 
     F = fun(#alpaca_fun_version{}=FV, {Env, Map, NewVersions}) ->
-                #alpaca_fun_version{args=Args, body=Body} = FV,
+                #alpaca_fun_version{args=Args, body=FunBody} = FV,
                 {Env2, M3, Args2} = rebind_args(Env, Map, Args),
-                {Env3, _M4, Body2} = rename_bindings(Env2, M3, Body),
+                {Env3, _M4, FunBody2} = rename_bindings(Env2, M3, FunBody),
                 FV2 = FV#alpaca_fun_version{
                         args=Args2,
-                        body=Body2},
+                        body=FunBody2},
                 %% As with patterns and clauses we deliberately
                 %% throw away the rename map here so that the
                 %% same symbols can be reused by distinctly
                 %% different function definitions.
                 {Env3, Map, [FV2|NewVersions]}
            end,
-    {Env3, Map2, Vs2} = lists:foldl(F, {En2, M2, []}, Vs),
-    NewDef = Def#alpaca_fun_def{name={symbol, L, NewName}, versions=lists:reverse(Vs2)},
-    {Env3, Map2, NewDef};
+    case Expr of
+        #alpaca_fun{versions=Vs}=Def ->
+            {Env3, Map2, Vs2} = lists:foldl(F, {En2, M2, []}, Vs),
+            {Env4, Map3, Body2} = rename_bindings(Env3, Map2, Body),
+            NewDef = Binding#alpaca_binding{
+                       name={symbol, L, NewName},
+                       bound_expr=Def#alpaca_fun{
+                                    versions=lists:reverse(Vs2)},
+                       body=Body2},
+            {Env4, Map3, NewDef};
+        _ ->
+            {Env3, Map2, Expr2} = rename_bindings(En2, M2, Expr),
+            {Env4, Map3, Body2} = rename_bindings(Env3, Map2, Body),
+            {Env3, Map2, Binding#alpaca_binding{
+                           name={symbol, L, NewName},
+                           bound_expr=Expr2,
+                           body=Body2}}
+    end;
 
 rename_bindings(#env{next_var=NextVar}=Env, Map, #var_binding{}=VB) ->
     #var_binding{name={symbol, L, N}, to_bind=TB, expr=E} = VB,
@@ -463,7 +525,8 @@ rename_bindings(Env, Map, #alpaca_apply{expr=N, args=Args}=App) ->
     ModFuns = fun () ->
                       Mod = Env#env.current_module,
                       #alpaca_module{functions=Fs} = Mod,
-                      [{{X, A}, local} || #alpaca_fun_def{name={_, _, X}, arity=A} <- Fs]
+                      NameAndArity = lists:map(fun name_and_arity/1, Fs),
+                      [{{X, A}, local} || {X, A} <- NameAndArity]
               end,
     ImpFuns = fun () ->
                       Mod = Env#env.current_module,
@@ -577,13 +640,12 @@ rename_bindings(Env, Map, {symbol, L, N}=S) ->
             %% try to resolve the symbol from imports:
             Mod = Env#env.current_module,
             Funs = Mod#alpaca_module.functions,
-            case [FN || #alpaca_fun_def{name=FN} <- Funs, FN =:= N] of
+            case [FN || #alpaca_binding{name=FN} <- Funs, FN =:= N] of
                 [_|_] -> {Env, Map, S};
                 [] ->
                     Imports = Mod#alpaca_module.function_imports,
                     case [{M, A} || {FN, {M, A}} <- Imports, FN =:= N] of
                         [{Module, Arity}|_] ->
-                            io:format("Rewriting ~s to ~w~n", [N, Arity]),
                             FR = #alpaca_far_ref{
                                     module=Module,
                                     name=N,
@@ -830,11 +892,10 @@ defn_test_() ->
      %% transparent
      ?_assertMatch(
         {ok, 
-         #alpaca_fun_def{name={symbol, 1, "x"},
-                       versions=[#alpaca_fun_version{
-                                    args=[], 
-                                    body={int, 1, 5}}]}},
-                   parse(alpaca_scanner:scan("let x=5"))),
+         #alpaca_binding{
+            name={symbol, 1, "x"},
+            bound_expr={int, 1, 5}}},
+        parse(alpaca_scanner:scan("let x=5"))),
      ?_assertMatch(
         {ok, {error, non_literal_value, {symbol, 1, "x"}, 
                      {alpaca_apply,undefined,1,
@@ -910,37 +971,45 @@ defn_test_() ->
         parse(alpaca_scanner:scan("let x=[1, (sideEffectingFun 5)]"))),        
      ?_assertMatch(
         {ok, 
-         #alpaca_fun_def{name={symbol, 1, "double"},
-                       versions=[#alpaca_fun_version{
-                                    args=[{symbol, 1, "x"}],
-                                    body=#alpaca_apply{
-                                            type=undefined,
-                                            expr={bif, '+', 1, erlang, '+'},
-                                            args=[{symbol, 1, "x"},
-                                                  {symbol, 1, "x"}]}}]}},
+         #alpaca_binding{
+            name={symbol, 1, "double"},
+            bound_expr=#alpaca_fun{
+                          versions=[#alpaca_fun_version{
+                                       args=[{symbol, 1, "x"}],
+                                       body=#alpaca_apply{
+                                               type=undefined,
+                                               expr={bif, '+', 1, erlang, '+'},
+                                               args=[{symbol, 1, "x"},
+                                                     {symbol, 1, "x"}]}}]}}},
         parse(alpaca_scanner:scan("let double x = x + x"))),
      ?_assertMatch(
-        {ok, #alpaca_fun_def{name={symbol, 1, "add"},
-                           versions=[#alpaca_fun_version{
-                                        args=[{symbol, 1, "x"}, 
-                                              {symbol, 1, "y"}],
-                                        body=#alpaca_apply{
-                                                type=undefined,
-                                                expr={bif, '+', 1, erlang, '+'},
-                                                args=[{symbol, 1, "x"},
-                                                      {symbol, 1, "y"}]}}]}},
+        {ok, 
+         #alpaca_binding{
+            name={symbol, 1, "add"},
+            bound_expr=#alpaca_fun{
+                          versions=[#alpaca_fun_version{
+                                       args=[{symbol, 1, "x"}, 
+                                             {symbol, 1, "y"}],
+                                       body=#alpaca_apply{
+                                               type=undefined,
+                                               expr={bif, '+', 1, erlang, '+'},
+                                               args=[{symbol, 1, "x"},
+                                                     {symbol, 1, "y"}]}}]}}},
         parse(alpaca_scanner:scan("let add x y = x + y"))),
         ?_assertMatch(
-            {ok, #alpaca_fun_def{name={symbol, 1, "(<*>)"},
-                            versions=[#alpaca_fun_version{
-                                            args=[{symbol, 1, "x"}, 
-                                                {symbol, 1, "y"}],
-                                            body=#alpaca_apply{
-                                                    type=undefined,
-                                                    expr={bif, '+', 1, erlang, '+'},
-                                                    args=[{symbol, 1, "x"},
-                                                        {symbol, 1, "y"}]}}]}},
-        parse(alpaca_scanner:scan("let (<*>) x y = x + y")))
+            {ok, 
+             #alpaca_binding{
+                name={symbol, 1, "(<*>)"},
+                bound_expr=#alpaca_fun{
+                              versions=[#alpaca_fun_version{
+                                           args=[{symbol, 1, "x"}, 
+                                                 {symbol, 1, "y"}],
+                                           body=#alpaca_apply{
+                                                   type=undefined,
+                                                   expr={bif, '+', 1, erlang, '+'},
+                                                   args=[{symbol, 1, "x"},
+                                                         {symbol, 1, "y"}]}}]}}},
+           parse(alpaca_scanner:scan("let (<*>) x y = x + y")))
     ].
 
 float_math_test_() ->
@@ -953,87 +1022,98 @@ float_math_test_() ->
 let_binding_test_() ->
     [?_assertMatch(
         {ok, 
-         #fun_binding{
-            def=#alpaca_fun_def{
-                   name={symbol, 1, "double"},
-                   versions=[#alpaca_fun_version{
-                                args=[{symbol, 1, "x"}],
-                                body=#alpaca_apply{
-                                        type=undefined,
-                                        expr={bif, '+', 1, erlang, '+'},
-                                        args=[{symbol, 1, "x"},
-                                              {symbol, 1, "x"}]}}]},
-            expr=#alpaca_apply{
+         #alpaca_binding{
+            name={symbol, 1, "double"},
+            bound_expr=#alpaca_fun{
+                          versions=[#alpaca_fun_version{
+                                       args=[{symbol, 1, "x"}],
+                                       body=#alpaca_apply{
+                                               type=undefined,
+                                               expr={bif, '+', 1, erlang, '+'},
+                                               args=[{symbol, 1, "x"},
+                                                     {symbol, 1, "x"}]}}]},
+            body=#alpaca_apply{
                     expr={symbol, 1, "double"},
                     args=[{int, 1, 2}]}}},
         parse(alpaca_scanner:scan("let double x = x + x in double 2"))),
-     ?_assertMatch({ok, #var_binding{
+     ?_assertMatch({ok, #alpaca_binding{
                            name={symbol, 1, "x"},
-                           to_bind=#alpaca_apply{
-                                      expr={symbol, 1, "double"},
-                                      args=[{int, 1, 2}]},
-                           expr=#alpaca_apply{
+                           bound_expr=#alpaca_apply{
+                                         expr={symbol, 1, "double"},
+                                         args=[{int, 1, 2}]},
+                           body=#alpaca_apply{
                                    expr={symbol, 1, "double"},
                                    args=[{symbol, 1, "x"}]}}},
                    parse(alpaca_scanner:scan("let x = double 2 in double x"))),
      ?_assertMatch(
         {ok, 
-         #alpaca_fun_def{
+         #alpaca_binding{
             name={symbol, 1, "doubler"},
-            versions=[#alpaca_fun_version{
-                         args=[{symbol, 1, "x"}],
-                         body=#fun_binding{
-                                 def=#alpaca_fun_def{
-                                        name={symbol, 2, "double"},
-                                        versions=[#alpaca_fun_version{
-                                                     args=[{symbol, 2, "x"}],
-                                                     body=#alpaca_apply{
-                                                             type=undefined,
-                                                             expr={bif, '+', 2, erlang, '+'},
-                                                             args=[{symbol, 2, "x"},
-                                                                   {symbol, 2, "x"}]}}]},
-                                 expr=#alpaca_apply{
-                                         expr={symbol, 3, "double"},
-                                         args=[{int, 3, 2}]}}}]}},
+            bound_expr=
+                #alpaca_fun{
+                   versions=
+                       [#alpaca_fun_version{
+                           args=[{symbol, 1, "x"}],
+                           body=
+                               #alpaca_binding{
+                                  name={symbol, 2, "double"},
+                                  bound_expr=
+                                      #alpaca_fun{
+                                         versions=
+                                             [#alpaca_fun_version{
+                                                 args=[{symbol, 2, "x"}],
+                                                 body=#alpaca_apply{
+                                                         type=undefined,
+                                                         expr={bif, '+', 2, erlang, '+'},
+                                                         args=[{symbol, 2, "x"},
+                                                               {symbol, 2, "x"}]}}]},
+                                  body=#alpaca_apply{
+                                          expr={symbol, 3, "double"},
+                                          args=[{int, 3, 2}]}}}]}}},
         parse(alpaca_scanner:scan(
                 "let doubler x =\n"
                 "  let double x = x + x in\n"
                 "  double 2"))),
      ?_assertMatch(
         {ok, 
-         #alpaca_fun_def{
+         #alpaca_binding{
             name={symbol,1,"my_fun"},
-            versions=[#alpaca_fun_version{
-                         args=[{symbol,1,"x"},{symbol,1,"y"}],
-                         body=#fun_binding{
-                                 def=#alpaca_fun_def{
-                                        name={symbol,1,"xer"},
-                                        versions=[#alpaca_fun_version{
-                                                     args=[{symbol,1,"a"}],
-                                                     body=#alpaca_apply{
-                                                             type=undefined,
-                                                             expr={bif, '+', 1, erlang, '+'},
-                                                             args=[{symbol,1,"a"},
-                                                                   {symbol,1,"a"}]}}]},
-                                 expr=#fun_binding{
-                                         def=#alpaca_fun_def{
-                                                name={symbol,1,"yer"},
-                                                versions=[#alpaca_fun_version{
-                                                             args=[{symbol,1,"b"}],
-                                                             body=#alpaca_apply{
-                                                                     type=undefined,
-                                                                     expr={bif, '+', 1, erlang, '+'},
-                                                                     args=[{symbol,1,"b"},
-                                                                           {symbol,1,"b"}]}}]},
-                                         expr=#alpaca_apply{
-                                                 type=undefined,
-                                                 expr={bif, '+', 1, erlang, '+'},
-                                                 args=[#alpaca_apply{
-                                                          expr={symbol,1,"xer"},
-                                                          args=[{symbol,1,"x"}]},
-                                                       #alpaca_apply{
-                                                          expr={symbol,1,"yer"},
-                                                          args=[{symbol,1,"y"}]}]}}}}]}},
+            bound_expr=
+                #alpaca_fun{
+                   versions=
+                       [#alpaca_fun_version{
+                           args=[{symbol,1,"x"},{symbol,1,"y"}],
+                           body=#alpaca_binding{
+                                   name={symbol,1,"xer"},
+                                   bound_expr=
+                                       #alpaca_fun{
+                                          versions=[#alpaca_fun_version{
+                                                       args=[{symbol,1,"a"}],
+                                                       body=#alpaca_apply{
+                                                               type=undefined,
+                                                               expr={bif, '+', 1, erlang, '+'},
+                                                               args=[{symbol,1,"a"},
+                                                                     {symbol,1,"a"}]}}]},
+                                   body=#alpaca_binding{
+                                           name={symbol,1,"yer"},
+                                           bound_expr=
+                                               #alpaca_fun{
+                                                  versions=[#alpaca_fun_version{
+                                                               args=[{symbol,1,"b"}],
+                                                               body=#alpaca_apply{
+                                                                       type=undefined,
+                                                                       expr={bif, '+', 1, erlang, '+'},
+                                                                       args=[{symbol,1,"b"},
+                                                                             {symbol,1,"b"}]}}]},
+                                           body=#alpaca_apply{
+                                                   type=undefined,
+                                                   expr={bif, '+', 1, erlang, '+'},
+                                                   args=[#alpaca_apply{
+                                                            expr={symbol,1,"xer"},
+                                                            args=[{symbol,1,"x"}]},
+                                                         #alpaca_apply{
+                                                            expr={symbol,1,"yer"},
+                                                            args=[{symbol,1,"y"}]}]}}}}]}}},
         parse(alpaca_scanner:scan(
                 "let my_fun x y ="
                 "  let xer a = a + a in"
@@ -1135,26 +1215,31 @@ module_with_let_test() ->
        [#alpaca_module{
            name='test_mod',
            function_exports=[{"add",2}],
-           functions=[#alpaca_fun_def{
-                         name={symbol,5,"add"},
-                         versions=[#alpaca_fun_version{
-                                      args=[{symbol,5,"svar_0"},{symbol,5,"svar_1"}],
-                                      body=#fun_binding{
-                                              def=#alpaca_fun_def{
-                                                     name={symbol,6,"svar_2"},
-                                                     versions=[#alpaca_fun_version{
-                                                                  args=[{symbol,6,"svar_3"},
-                                                                        {symbol,6,"svar_4"}],
-                                                                  body=#alpaca_apply{
-                                                                          type=undefined,
-                                                                          expr={bif, '+', 6, erlang, '+'},
-                                                                          args=[{symbol,6,"svar_3"},
-                                                                                {symbol,6,"svar_4"}]}}]},
-                                              expr=#alpaca_apply{
-                                                      expr={symbol,7,"svar_2"},
-                                                      args=[{symbol,7,"svar_0"},
-                                                            {symbol,7,"svar_1"}]}}}]}]}]},
-       test_make_modules([Code])).
+           functions=
+               [#alpaca_binding{
+                   name={symbol,5,"add"},
+                   bound_expr=
+                       #alpaca_fun{
+                          versions=
+                              [#alpaca_fun_version{
+                                  args=[{symbol,5,"svar_0"},{symbol,5,"svar_1"}],
+                                  body=#alpaca_binding{
+                                          name={symbol,6,"svar_2"},
+                                          bound_expr=
+                                              #alpaca_fun{
+                                                 versions=[#alpaca_fun_version{
+                                                              args=[{symbol,6,"svar_3"},
+                                                                    {symbol,6,"svar_4"}],
+                                                              body=#alpaca_apply{
+                                                                      type=undefined,
+                                                                      expr={bif, '+', 6, erlang, '+'},
+                                                                      args=[{symbol,6,"svar_3"},
+                                                                            {symbol,6,"svar_4"}]}}]},
+                                          body=#alpaca_apply{
+                                                  expr={symbol,7,"svar_2"},
+                                                  args=[{symbol,7,"svar_0"},
+                                                        {symbol,7,"svar_1"}]}}}]}}]}]},
+                 test_make_modules([Code])).
 
 match_test_() ->
     [?_assertMatch(
@@ -1340,38 +1425,50 @@ simple_module_test() ->
        [#alpaca_module{
            name='test_mod',
            function_exports=[{"add",2},{"sub",2}],
-           functions=[
-                      #alpaca_fun_def{
-                         name={symbol, 5, "adder"},
-                         versions=[#alpaca_fun_version{
-                                      args=[{symbol, 5, "svar_0"},
-                                            {symbol,5 , "svar_1"}],
-                                      body=#alpaca_apply{type=undefined,
-                                                       expr={bif, '+', 5, erlang, '+'},
-                                                       args=[{symbol, 5, "svar_0"},
-                                                             {symbol,5,"svar_1"}]}}]},
-                      #alpaca_fun_def{
-                         name={symbol,7,"add1"},
-                         versions=[#alpaca_fun_version{
-                                      args=[{symbol,7,"svar_2"}],
-                                      body=#alpaca_apply{expr={symbol,7,"adder"},
-                                                       args=[{symbol,7,"svar_2"},
-                                                             {int,7,1}]}}]},
-                      #alpaca_fun_def{
-                         name={symbol,9,"add"},
-                         versions=[#alpaca_fun_version{
-                                      args=[{symbol,9,"svar_3"},{symbol,9,"svar_4"}],
-                                      body=#alpaca_apply{expr={symbol,9,"adder"},
-                                                       args=[{symbol,9,"svar_3"},
-                                                             {symbol,9,"svar_4"}]}}]},
-                      #alpaca_fun_def{
-                         name={symbol,11,"sub"},
-                         versions=[#alpaca_fun_version{
-                                      args=[{symbol,11,"svar_5"},{symbol,11,"svar_6"}],
-                                      body=#alpaca_apply{type=undefined,
-                                                       expr={bif, '-', 11, erlang, '-'},
-                                                       args=[{symbol,11,"svar_5"},
-                                                             {symbol,11,"svar_6"}]}}]}]}]},
+           functions=
+               [#alpaca_binding{
+                   name={symbol, 5, "adder"},
+                   bound_expr=
+                       #alpaca_fun{
+                          versions=
+                              [#alpaca_fun_version{
+                                  args=[{symbol, 5, "svar_0"},
+                                        {symbol,5 , "svar_1"}],
+                                  body=#alpaca_apply{type=undefined,
+                                                     expr={bif, '+', 5, erlang, '+'},
+                                                     args=[{symbol, 5, "svar_0"},
+                                                           {symbol,5,"svar_1"}]}}]}},
+                #alpaca_binding{
+                   name={symbol,7,"add1"},
+                   bound_expr=
+                       #alpaca_fun{
+                          versions=
+                              [#alpaca_fun_version{
+                                  args=[{symbol,7,"svar_2"}],
+                                  body=#alpaca_apply{expr={symbol,7,"adder"},
+                                                     args=[{symbol,7,"svar_2"},
+                                                           {int,7,1}]}}]}},
+                #alpaca_binding{
+                   name={symbol,9,"add"},
+                   bound_expr=
+                       #alpaca_fun{
+                          versions=
+                              [#alpaca_fun_version{
+                                  args=[{symbol,9,"svar_3"},{symbol,9,"svar_4"}],
+                                  body=#alpaca_apply{expr={symbol,9,"adder"},
+                                                     args=[{symbol,9,"svar_3"},
+                                                           {symbol,9,"svar_4"}]}}]}},
+                #alpaca_binding{
+                   name={symbol,11,"sub"},
+                   bound_expr=
+                       #alpaca_fun{
+                          versions=
+                              [#alpaca_fun_version{
+                                  args=[{symbol,11,"svar_5"},{symbol,11,"svar_6"}],
+                                  body=#alpaca_apply{type=undefined,
+                                                     expr={bif, '-', 11, erlang, '-'},
+                                                     args=[{symbol,11,"svar_5"},
+                                                           {symbol,11,"svar_6"}]}}]}}]}]},
        test_make_modules([Code])).
 
 break_test() ->
@@ -1383,17 +1480,12 @@ break_test() ->
        [#alpaca_module{
            name='test_mod',
            function_exports=[],
-           functions=[#alpaca_fun_def{
+           functions=[#alpaca_binding{
                          name={symbol, 4, "a"},
-                         versions=[#alpaca_fun_version{
-                                      args=[],
-                                    body={int, 4, 5}}]},
-                      #alpaca_fun_def{
+                         bound_expr={int, 4, 5}},
+                      #alpaca_binding{
                          name={symbol, 6, "b"},
-                         versions=[#alpaca_fun_version{
-                                      args=[],
-                                      body={int, 6, 6}}]}               
-       ]}]},
+                         bound_expr={int, 6, 6}}]}]},
        test_make_modules([Code])).
     
 
@@ -1417,60 +1509,72 @@ rebinding_test_() ->
     {ok, F} = test_parse("let f x y = match x with\n"
                          " h :: y -> h"),
 
-    [?_assertMatch({_, _, #alpaca_fun_def{
-                             name={symbol, 1, "f"},
-                             versions=[#alpaca_fun_version{
-                                          args=[{symbol, 1, "svar_0"}],
-                                          body=#var_binding{
-                                                  name={symbol, 1, "svar_1"},
-                                                  to_bind={int, 1, 2},
-                                                  expr=#alpaca_apply{
-                                                          expr={bif, '+', 1, 'erlang', '+'},
-                                                          args=[{symbol, 1, "svar_0"},
-                                                                {symbol, 1, "svar_1"}]}}}]}},
+    [?_assertMatch(
+        {_, _, 
+         #alpaca_binding{
+            name={symbol, 1, "f"},
+            bound_expr=#alpaca_fun{
+                          versions=[#alpaca_fun_version{
+                                       args=[{symbol, 1, "svar_0"}],
+                                       body=#alpaca_binding{
+                                               name={symbol, 1, "svar_1"},
+                                               bound_expr={int, 1, 2},
+                                               body=#alpaca_apply{
+                                                       expr={bif, '+', 1, 'erlang', '+'},
+                                                       args=[{symbol, 1, "svar_0"},
+                                                             {symbol, 1, "svar_1"}]}}}]}}},
                    rename_bindings(#env{}, A)),
      ?_assertThrow({parse_error, undefined, 2, {duplicate_definition, "x"}},
                    rename_bindings(#env{}, B)),
      ?_assertMatch(
-        {_, _, #alpaca_fun_def{
-                  name={symbol, 1, "f"},
-                  versions=[#alpaca_fun_version{
-                               args=[{symbol, 1, "svar_0"}],
-                               body=#alpaca_match{
+        {_, _, 
+         #alpaca_binding{
+            name={symbol, 1, "f"},
+            bound_expr=
+                #alpaca_fun{
+                   versions=[#alpaca_fun_version{
+                                args=[{symbol, 1, "svar_0"}],
+                                body=#alpaca_match{
                                        match_expr={symbol, 1, "svar_0"},
-                                       clauses=[#alpaca_clause{
-                                                   pattern=#alpaca_tuple{
-                                                              values=[{symbol, 2, "svar_1"},
-                                                                      {int, 2, 0}]},
-                                                   result={symbol, 2, "svar_1"}},
-                                                #alpaca_clause{
-                                                   pattern=#alpaca_tuple{
-                                                              values=[{symbol, 3, "svar_2"},
-                                                                      {symbol, 3, "svar_3"}]},
-                                                   result={symbol, 3, "svar_3"}}]}}]}},
-        rename_bindings(#env{}, C)),
+                                       clauses=
+                                            [#alpaca_clause{
+                                                pattern=#alpaca_tuple{
+                                                           values=[{symbol, 2, "svar_1"},
+                                                                   {int, 2, 0}]},
+                                                result={symbol, 2, "svar_1"}},
+                                             #alpaca_clause{
+                                                pattern=#alpaca_tuple{
+                                                           values=[{symbol, 3, "svar_2"},
+                                                                   {symbol, 3, "svar_3"}]},
+                                                result={symbol, 3, "svar_3"}}]}}]}}},
+         rename_bindings(#env{}, C)),
      ?_assertThrow({parse_error, undefined, 2, {duplicate_definition, "x"}},
                    rename_bindings(#env{}, D)),
      ?_assertMatch(
         {_, _,
-         #alpaca_fun_def{
-            versions=[#alpaca_fun_version{ 
-                         body=#alpaca_match{
-                                 match_expr={symbol, 1, "svar_0"},
-                                 clauses=[#alpaca_clause{
-                                             pattern=#alpaca_cons{
-                                                        head={'_', 2},
-                                                        tail=#alpaca_cons{
-                                                                head={symbol, 2, "svar_1"},
-                                                                tail=#alpaca_cons{
-                                                                        head={int, 2, 0},
-                                                                        tail={nil, 0}}}},
-                                             result={symbol, 2, "svar_1"}},
-                                          #alpaca_clause{
-                                             pattern=#alpaca_cons{
-                                                        head={symbol, 3, "svar_2"},
-                                                        tail={symbol, 3, "svar_3"}},
-                                             result={symbol, 3, "svar_2"}}]}}]}},
+         #alpaca_binding{
+            bound_expr=
+                #alpaca_fun{
+                   versions=
+                       [#alpaca_fun_version{ 
+                           body=
+                               #alpaca_match{
+                                  match_expr={symbol, 1, "svar_0"},
+                                  clauses=[#alpaca_clause{
+                                              pattern=
+                                                  #alpaca_cons{
+                                                     head={'_', 2},
+                                                     tail=#alpaca_cons{
+                                                             head={symbol, 2, "svar_1"},
+                                                             tail=#alpaca_cons{
+                                                                     head={int, 2, 0},
+                                                                     tail={nil, 0}}}},
+                                              result={symbol, 2, "svar_1"}},
+                                           #alpaca_clause{
+                                              pattern=#alpaca_cons{
+                                                         head={symbol, 3, "svar_2"},
+                                                         tail={symbol, 3, "svar_3"}},
+                                              result={symbol, 3, "svar_2"}}]}}]}}},
         rename_bindings(#env{}, E)),
      ?_assertThrow({parse_error, undefined, 2, {duplicate_definition, "y"}},
                    rename_bindings(#env{}, F))
@@ -1537,7 +1641,9 @@ ambiguous_type_expressions_test() ->
 expand_exports_test_() ->
     [fun() ->
              Def = fun(Name, Arity) ->
-                           #alpaca_fun_def{name={symbol, 0, Name}, arity=Arity}
+                           #alpaca_binding{
+                              name={symbol, 0, Name},
+                              bound_expr=#alpaca_fun{arity=Arity}}
                    end,
 
              Ms = [#alpaca_module{
@@ -1612,15 +1718,16 @@ import_rewriting_test_() ->
                 [#alpaca_module{name=a},
                  #alpaca_module{
                     name=b,
-                    functions=[#alpaca_fun_def{
-                                  versions=[#alpaca_fun_version{
-                                               body=#alpaca_apply{
-                                                       expr=#alpaca_far_ref{
-                                                               module=a,
-                                                               name="add",
-                                                               arity=2}
-                                                      }}]
-                                 }]}]},
+                    functions=[#alpaca_binding{
+                                  bound_expr=#alpaca_fun{
+                                                versions=[#alpaca_fun_version{
+                                                             body=#alpaca_apply{
+                                                                     expr=#alpaca_far_ref{
+                                                                             module=a,
+                                                                             name="add",
+                                                                             arity=2}
+                                                                    }}]
+                                               }}]}]},
                 test_make_modules([Code1, Code2]))
      end
     , fun() ->
@@ -1633,20 +1740,22 @@ import_rewriting_test_() ->
                   "import a.(|>)\n\n"
                   "let add_ten x = x + 10\n\n"
                   "let f () = 2 |> add_ten",
-              ?assertMatch({ok,
-                 [#alpaca_module{name=a},
-                  #alpaca_module{
-                     name=b,
-                     functions=[_,
-                                #alpaca_fun_def{
-                                   versions=[#alpaca_fun_version{
-                                                body=#alpaca_apply{
-                                                        expr=#alpaca_far_ref{
-                                                                module=a,
-                                                                name="(|>)",
-                                                                arity=2}
-                                                       }}]
-                                  }]}]},
+              ?assertMatch(
+                 {ok,
+                  [#alpaca_module{name=a},
+                   #alpaca_module{
+                      name=b,
+                      functions=[_,
+                                 #alpaca_binding{
+                                    bound_expr=#alpaca_fun{
+                                                  versions=[#alpaca_fun_version{
+                                                               body=#alpaca_apply{
+                                                                       expr=#alpaca_far_ref{
+                                                                               module=a,
+                                                                               name="(|>)",
+                                                                               arity=2}
+                                                                      }}]
+                                                 }}]}]},
                  test_make_modules([Code1, Code2]))
       end
     , fun() ->

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -61,7 +61,6 @@
 make_modules(Code) ->
     try
       Modules = [parse_module(SourceCode) || SourceCode <- Code],
-      io:format("Modules parsed~n", []),
       {ok, rename_and_resolve(Modules)}
     catch
         throw:{parse_error, _, _, _}=Err -> {error, Err}
@@ -270,7 +269,6 @@ rebind_and_validate_module(NextVarNum, #alpaca_module{}=Mod, Modules) ->
 %% All available modules required so that we can rewrite applications of
 %% functions not in Mod to inter-module calls.
 rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
-    io:format("Rebind and validate~n", []),
     #alpaca_module{name=_MN, functions=Funs}=Mod,
     BindingF = fun(#alpaca_binding{name={_, _, N}, bound_expr=#alpaca_fun{arity=A}}) ->
                        {N, A};
@@ -284,8 +282,6 @@ rebind_and_validate_functions(NextVarNum, #alpaca_module{}=Mod, Modules) ->
                current_bindings=Bindings,
                current_module=Mod,
                modules=Modules},
-
-    io:format("Names and arities for rebinding and validating~n", []),
 
     F = fun(F, {E, Memo}) ->
                 {#env{next_var=NV2, rename_map=_M}, M2, F2} = rename_bindings(E, F),
@@ -428,7 +424,6 @@ rename_bindings(Environment, #alpaca_binding{}=TopLevel) ->
             {Env, M2, Vs2} = lists:foldl(F, {Environment, maps:new(), []}, Vs),
             {Env, M2, TopLevel#alpaca_binding{bound_expr=Expr#alpaca_fun{versions=Vs2}}};
         _ ->
-            io:format("Rename top-level val~n", []),
             {Env, _, E} =  rename_bindings(Environment, maps:new(), Expr),
             {Env, maps:new(), TopLevel#alpaca_binding{bound_expr=E}}
     end.

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1806,6 +1806,17 @@ invalid_base_type_parameters_test_() ->
                    test_make_modules([Code]))
     end, Types).
 
+invalid_fun_parameter_test_() ->
+    P = fun(Code) -> parse(alpaca_scanner:scan(Code)) end,
+
+    [?_assertMatch({error, {1, _, {invalid_fun_parameter, _}}},
+                   P("fn (fn x -> x + 1) -> 2"))
+     , ?_assertMatch({error, {1, _, {invalid_fun_parameter, _}}},
+                     P("let f (fn x -> x + 1) = 2"))
+     , ?_assertMatch({error, {1, _, {invalid_fun_parameter, _}}},
+                     P("let f = fn (fn x -> x + 1) -> 2"))
+    ].
+
 test_make_modules(Sources) ->
     NamedSources = lists:map(fun(C) -> {?FILE, C} end, Sources),
     make_modules(NamedSources).

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -403,7 +403,7 @@ next_batch([Token|Tail], Memo) ->
 
 -spec rename_bindings(
         Env::#env{},
-        TopLevel::alpaca_fun_def()) -> {#env{}, map(), alpaca_fun_def()}.
+        TopLevel::alpaca_binding()) -> {#env{}, map(), alpaca_binding()}.
 rename_bindings(Environment, #alpaca_binding{}=TopLevel) ->
     #alpaca_binding{name={symbol, _, _}, bound_expr=Expr} = TopLevel,
     case Expr of
@@ -491,23 +491,6 @@ rename_bindings(#env{current_module=Mod}=StartEnv, M,
                            name={symbol, L, NewName},
                            bound_expr=Expr2,
                            body=Body2}}
-    end;
-
-rename_bindings(#env{next_var=NextVar}=Env, Map, #var_binding{}=VB) ->
-    #var_binding{name={symbol, L, N}, to_bind=TB, expr=E} = VB,
-    case maps:get(N, Map, undefined) of
-        undefined ->
-            Synth = next_var(NextVar),
-            M2 = maps:put(N, Synth, Map),
-            {Env2, M3, TB2} = rename_bindings(Env#env{next_var=NextVar+1}, M2, TB),
-            {Env3, M4, E2} = rename_bindings(Env2, M3, E),
-            VB2 = #var_binding{
-                     name={symbol, L, Synth},
-                     to_bind=TB2,
-                     expr=E2},
-            {Env3, M4, VB2};
-        _ ->
-            parse_error(Env#env.current_module, L, {duplicate_definition, N})
     end;
 
 rename_bindings(Env, Map, #alpaca_apply{expr=N, args=Args}=App) ->

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -488,7 +488,7 @@ rename_bindings(#env{current_module=Mod}=StartEnv, M,
         _ ->
             {Env3, Map2, Expr2} = rename_bindings(En2, M2, Expr),
             {Env4, Map3, Body2} = rename_bindings(Env3, Map2, Body),
-            {Env3, Map2, Binding#alpaca_binding{
+            {Env4, Map3, Binding#alpaca_binding{
                            name={symbol, L, NewName},
                            bound_expr=Expr2,
                            body=Body2}}
@@ -1144,9 +1144,6 @@ import_test_() ->
                  "module two_lines_of_imports\n\n"
                  "import foo.bar/2\n\n"
                  "import math.[add/2, sub/2, mult]",
-             Code2 =
-                 "module foo\n\nexport bar/2",
-             Code3 = "module math\n\nexport add/2, sub/2, mult/1",
 
              ?assertMatch(
                 #alpaca_module{

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -232,6 +232,7 @@ term_line(Term) ->
         #alpaca_record_transform{line=L} -> L;
         #alpaca_tuple{values=[H|_]} -> term_line(H);
         #alpaca_type_apply{name=N} -> term_line(N);
+        #alpaca_fun{line=L} -> L;
         #alpaca_fun_version{line=L} -> L;
         #type_constructor{line=L} -> L
     end.

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -145,6 +145,9 @@ rewrite_lambdas(#alpaca_binding{bound_expr=BE, body=Body}=AB, NextFun, Memo) ->
 rewrite_lambdas(#alpaca_apply{args=As}=Apply, NextFun, Memo) ->
     {NF, Args2, BMemo} = rewrite_seq_lambdas(As, NextFun),
     {NF, Apply#alpaca_apply{args=Args2}, [BMemo ++ Memo]};
+rewrite_lambdas(#alpaca_type_apply{arg=Arg}=Apply, NextFun, Memo) ->
+    {NF, Arg2, Bindings} = rewrite_lambdas(Arg, NextFun, []),
+    {NF, Apply#alpaca_type_apply{arg=Arg2}, Bindings ++ Memo};
 rewrite_lambdas(X, NextFun, Memo) ->
     {NextFun, X, Memo}.
 

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -113,10 +113,8 @@ gen_fun(Env,
 gen_fun(Env, #alpaca_binding{name={symbol, _, N}, bound_expr=Bound}) ->
     case Bound of
         #alpaca_fun{versions=[#alpaca_fun_version{args=Args, body=Body}]}=Def ->
-            io:format("Single version~n", []),
             case needs_pattern(Args) of
                 false ->
-                    io:format("No patterns~n", []),
                     FName = cerl:c_fname(list_to_atom(N), length(Args)),
                     A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
                     {_, B} = gen_expr(Env, Body),
@@ -522,11 +520,9 @@ gen_expr(#env{module_funs=Funs}=Env, #alpaca_binding{}=AB) ->
     #alpaca_binding{name={symbol, _, N}, bound_expr=BE, body=Body} = AB,
     case BE of
         #alpaca_fun{arity=Arity} ->
-            io:format("Arity ~w~n", [Arity]),
             NewEnv = Env#env{module_funs=[{N, Arity}|Funs]},
             case Body of
                 undefined ->
-                    io:format("No body~n", []),
                     {Env, gen_fun(NewEnv, AB)};
                 _ ->
                     {_, Exp} = gen_expr(NewEnv, Body),

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -396,12 +396,12 @@ gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
                             bound_expr=CurryExpr},
                gen_expr(Env2, Binding);
         _ ->
-            SynthBinding = #var_binding{
+            SynthBinding = #alpaca_binding{
                               name={symbol, L, FunName},
-                              to_bind=Expr,
-                              expr=#alpaca_apply{
-                                        line=L, expr={symbol, L, FunName},
-                                        args=Args}},
+                              bound_expr=Expr,
+                              body=#alpaca_apply{
+                                      line=L, expr={symbol, L, FunName},
+                                      args=Args}},
 
             gen_expr(Env2, SynthBinding)
     end;

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -454,10 +454,11 @@ infix -> term op term : make_infix('$2', '$1', '$3').
 
 literal_fun -> fn terms '->' simple_expr:
   {_, L} = '$1',
+  {ok, Args} = validate_args(L, '$2'),
   #alpaca_fun{line=L,
               arity=length('$2'),
               versions=[#alpaca_fun_version{
-                           args='$2',
+                           args=Args,
                            body='$4'}]}.
 
 %% ----- Errors (including throw, exit) --------------
@@ -740,6 +741,8 @@ validate_args(L, Args) ->
 
 validate_args(_L, [], GoodArgs) ->
     {ok, lists:reverse(GoodArgs)};
+validate_args(L, [#alpaca_fun{}=F|_], _) ->
+    return_error(L, {invalid_fun_parameter, F});
 validate_args(L, [#alpaca_match{}=E|_], _) ->
     return_error(L, {invalid_fun_parameter, E});
 validate_args(L, [#alpaca_spawn{}=E|_], _) ->

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -52,6 +52,7 @@ Rules.
 let         : {token, {'let', TokenLine}}.
 in          : {token, {in, TokenLine}}.
 fn          : {token, {fn, TokenLine}}.
+\x{03BB}    : {token, {fn, TokenLine}}.         % unicode lower-case lambda
 match       : {token, {match, TokenLine}}.
 with        : {token, {with, TokenLine}}.
 beam        : {token, {beam, TokenLine}}.
@@ -125,8 +126,9 @@ c"(\\"*|\\.|[^"\\])*" :
 
 [\*\/\%]   : {token, {int_math, TokenLine, TokenChars}}.
 {FLOAT_MATH} : {token, {float_math, TokenLine, TokenChars}}.
-->   : {token, {'->', TokenLine}}.
-_    : {token, {'_', TokenLine}}.
+->       : {token, {'->', TokenLine}}.
+\x{2192} : {token, {'->', TokenLine}}.          % unicode rightwards arrow
+_        : {token, {'_', TokenLine}}.
 
 %% Non-predefined infixes
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -51,6 +51,7 @@ Rules.
 %% Reserved words
 let         : {token, {'let', TokenLine}}.
 in          : {token, {in, TokenLine}}.
+fn          : {token, {fn, TokenLine}}.
 match       : {token, {match, TokenLine}}.
 with        : {token, {with, TokenLine}}.
 beam        : {token, {beam, TokenLine}}.

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -5302,6 +5302,25 @@ records_and_type_constructors_test_() ->
       end
     ].
 
+literal_fun_test_() ->
+    [?_assertMatch({{t_arrow, [t_int], t_int}, _},
+                   top_typ_of("fn x -> x + 1"))
+    , ?_assertMatch({{t_arrow, [t_int], t_int}, _},
+                    top_typ_of("let f = fn x -> x + 1"))
+    , fun() ->
+              Code =
+                  "module m \n"
+                  "let f () = \n"
+                  "  let g = fn x -> x + 1 in \n"
+                  "  g 2",
+              ?assertMatch(
+                 {ok, #alpaca_module{
+                         functions=[#alpaca_binding{
+                                       type={t_arrow, [t_unit], t_int}}]}},
+                 module_typ_and_parse(Code))
+      end
+    ].
+
 make_modules(Sources) ->
   NamedSources = lists:map(fun(C) -> {?FILE, C} end, Sources),
   {ok, Mods} = alpaca_ast_gen:make_modules(NamedSources),

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -2411,7 +2411,7 @@ typ_apply_no_recv(Env, Lvl, TypF, NextVar, Args, Line) ->
         Env::env(),
         ModuleName::atom(),
         FunName::string(),
-        Arity::integer()) -> {ok, alpaca_module(), alpaca_fun_def()} |
+        Arity::integer()) -> {ok, alpaca_module(), alpaca_binding()} |
                              {error,
                               {no_module, atom()} |
                               {not_exported, string(), integer()} |
@@ -2452,7 +2452,7 @@ extract_module_bindings(Env, ModuleName, BindingName) ->
 -spec get_fun(
         Module::alpaca_module(),
         FunName::string(),
-        Arity::integer()) -> {ok, alpaca_module(), alpaca_fun_def()} |
+        Arity::integer()) -> {ok, alpaca_module(), alpaca_binding()} |
                              {error, {not_found, atom(), string, integer()}}.
 get_fun(Module, FunName, Arity) ->
     case filter_to_fun(Module#alpaca_module.functions, FunName, Arity) of

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1572,11 +1572,13 @@ typ_of(Env, _Lvl, #alpaca_far_ref{module=Mod, name=N, line=_L, arity=A}) ->
     Env2 = Env#env{current_module=Module,
                    entered_modules=EnteredModules},
     {ok, #alpaca_module{functions=Funs}} = type_module(Module, Env2),
-    [Typ] = [Typ ||
-                #alpaca_binding{name={symbol, _, X}, bound_expr=#alpaca_fun{arity=Arity, type=Typ}} <- Funs,
-                N =:= X,
-                A =:= Arity
-            ],
+
+    [Typ] = [Typ || #alpaca_binding{
+                       name={symbol, _, X},
+                       type=Typ,
+                       bound_expr=#alpaca_fun{arity=Arity}} <- Funs,
+                    N =:= X,
+                    A =:= Arity],
 
     Err = fun() ->
                   [CurrMod|_] = Env#env.entered_modules,

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -5307,6 +5307,20 @@ literal_fun_test_() ->
                    top_typ_of("fn x -> x + 1"))
     , ?_assertMatch({{t_arrow, [t_int], t_int}, _},
                     top_typ_of("let f = fn x -> x + 1"))
+    , fun () ->
+              Code =
+                  "module m "
+                  "let map f [] = [] "
+                  "let map f (h :: t) = (f h) :: (map f t) "
+                  "let nested_fun () ="
+                  "  map (fn x -> (fn y -> y + 1) x) [1, 2, 3]",
+              ?assertMatch(
+                 {ok, #alpaca_module{
+                         functions=[_,
+                                    #alpaca_binding{
+                                       type={t_arrow, [t_unit], {t_list, t_int}}}]}},
+                 module_typ_and_parse(Code))
+      end
     , fun() ->
               Code =
                   "module m \n"

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1150,7 +1150,7 @@ inst_constructor_arg({t_map, KeyType, ValType}, Vs, Types, Env) ->
     {Env3, new_cell({t_map, KElem, VElem})};
 inst_constructor_arg({t_pid, MsgType}, Vs, Types, Env) ->
     {Env2, PidElem} = inst_constructor_arg(MsgType, Vs, Types, Env),
-    {Env, new_cell({t_pid, PidElem})};
+    {Env2, new_cell({t_pid, PidElem})};
 inst_constructor_arg(#alpaca_type{name={type_name, _, N}, vars=Vars, members=M1},
                      Vs, Types, Env) ->
     #alpaca_type{vars = V2, members=M2, module=Mod} = find_type(N, Types),
@@ -1195,7 +1195,7 @@ inst_constructor_arg({t_arrow, ArgTypes, RetType}, Vs, Types, Env) ->
         end,
     {Env2, InstantiatedArgs} = lists:foldl(F, {Env, []}, ArgTypes),
     {Env3, InstantiatedRet} = inst_constructor_arg(RetType, Vs, Types, Env2),
-    {Env, new_cell({t_arrow, lists:reverse(InstantiatedArgs), InstantiatedRet})};
+    {Env3, new_cell({t_arrow, lists:reverse(InstantiatedArgs), InstantiatedRet})};
 
 inst_constructor_arg(Arg, _, _, _) ->
     throw({error, {bad_constructor_arg, Arg}}).
@@ -1750,7 +1750,7 @@ typ_of(Env, Lvl, #alpaca_record_transform{additions=Adds, existing=Exists}) ->
 
     RecMems = [#t_record_member{name=N, type=T} || {N, T} <- maps:to_list(Deduped)],
     Rec = #t_record{members=RecMems, row_var=FlatVar},
-    {new_cell(Rec), NV2};
+    {new_cell(Rec), NV3};
 
 typ_of(Env, _Lvl, #alpaca_type_apply{name=N, arg=none}) ->
     case inst_type_arrow(Env, N) of

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -337,6 +337,7 @@ extract_type_name({type, Name, _, _}) -> Name.
 keywords() ->
     [<<"let">>,
      <<"in">>,
+     <<"fn">>,
      <<"match">>,
      <<"with">>,
      <<"beam">>,

--- a/test_files/lambda_examples.alp
+++ b/test_files/lambda_examples.alp
@@ -1,0 +1,28 @@
+module lambda_examples
+
+export map_lambda, no_sugar_internal_binding, no_sugar_top_binding
+export map_to_make_t, nested_fun, use_lambda
+
+let map f [] = []
+let map f (h :: t) = (f h) :: (map f t)
+
+-- Use a literal lambda/anonymous function:
+let map_lambda () = map (fn x -> x + 1) [1, 2, 3]
+
+-- Skip function binding syntax sugar for internal functions.
+let no_sugar_internal_binding () =
+  let f = fn x -> x + 1 in
+  f 2
+
+-- Skip the syntax sugar for function bindings at the top level.
+let no_sugar_top_binding = fn x -> x + 1
+
+type t 'a = T 'a
+
+let map_to_make_t list =
+  T (map (fn x -> x + 1) list)
+
+let nested_fun () =
+    map (fn x -> (fn y -> y + 1) x) [1, 2, 3]
+
+let use_lambda = λ x → x + 1


### PR DESCRIPTION
Lots of changes in here, broad strokes:
- removed `#alpaca_fun_def{}`, `#var_binding{}` and `#fun_binding{}` in favour of a single binding AST node for both top-level and internal bindings, `#alpaca_binding{}`.
- functions are actual values apart from bindings.
- added the ability to define lambdas with @danabr's proposed syntax, e.g. `fn a b -> a + b`.
- for fun I added the unicode lambda and right-arrow characters (iirc @tchoutri suggested this in IRC last year)

So with this PR this is legal Alpaca:

    let use_lambda = λ x → x + 1

Or the same:

    let use_lambda = fn x -> x + 1

See the file `test_files/lambda_examples.alp` for more.

@danabr and @lepoetemaudit this touches a lot of stuff both of you have worked on and it would not at all surprise me to learn I've done a bunch of inefficient or repetitive things that should be cleaned up.  If either of you have the time to give this a look I'd be most grateful!