### PR TITLE
Make the receiver type expressible

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -467,4 +467,10 @@ clause_style_test() ->
     ?assertEqual(zero, M:or_pipe(0)),
     code:delete(M).
 
+%% Check that we can use the receiver and rec types directly in an ADT.
+receiver_type_test() ->
+    Files = ["test_files/receiver_type.alp"],
+    [M] = compile_and_load(Files, []),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -137,19 +137,22 @@ poly_type -> symbol type_expressions :
   Members = '$2',
 
   case {N, Members} of
-      {"atom", Params}   -> type_arity_error(L, t_atom, Params);
-      {"binary", Params} -> type_arity_error(L, t_binary, Params);
-      {"bool", Params}   -> type_arity_error(L, t_bool, Params);
-      {"chars", Params}  -> type_arity_error(L, t_chars, Params);
-      {"float", Params}  -> type_arity_error(L, t_float, Params);
-      {"int", Params}    -> type_arity_error(L, t_int, Params);
-      {"list", [E]}      -> {t_list, E};
-      {"list", Params}   -> type_arity_error(L, t_list, Params);
-      {"map", [K, V]}    -> {t_map, K, V};
-      {"map", Params}    -> type_arity_error(L, t_map, Params);
-      {"pid", [T]}       -> {t_pid, T};
-      {"pid", Params}    -> type_arity_error(L, t_pid, Params);
-      {"string", Params} -> type_arity_error(L, t_string, Params);
+      {"atom", Params}           -> type_arity_error(L, t_atom, Params);
+      {"binary", Params}         -> type_arity_error(L, t_binary, Params);
+      {"bool", Params}           -> type_arity_error(L, t_bool, Params);
+      {"chars", Params}          -> type_arity_error(L, t_chars, Params);
+      {"float", Params}          -> type_arity_error(L, t_float, Params);
+      {"int", Params}            -> type_arity_error(L, t_int, Params);
+      {"list", [E]}              -> {t_list, E};
+      {"list", Params}           -> type_arity_error(L, t_list, Params);
+      {"map", [K, V]}            -> {t_map, K, V};
+      {"map", Params}            -> type_arity_error(L, t_map, Params);
+      {"receiver", [MsgT, ExpT]} -> {t_receiver, MsgT, ExpT};
+      {"receiver", Params}       -> type_arity_error(L, t_receiver, Params);
+      {"pid", [T]}               -> {t_pid, T};
+      {"pid", Params}            -> type_arity_error(L, t_pid, Params);
+      {"string", Params}         -> type_arity_error(L, t_string, Params);
+      {"rec", Params}            -> type_arity_error(L, t_rec, Params);
       _ ->
           %% Any concrete type in the type_expressions gets a synthesized variable name:
           Vars = make_vars_for_concrete_types('$2', L),
@@ -223,6 +226,8 @@ sub_type_expr -> symbol :
           return_error(L, {wrong_type_arity, t_pid, 0});
       "string" ->
           t_string;
+      "rec" ->
+          t_rec;
       _ ->
           #alpaca_type{name={type_name, L, N}, vars=[]} % not polymorphic
   end.

--- a/test_files/receiver_type.alp
+++ b/test_files/receiver_type.alp
@@ -1,0 +1,21 @@
+module receiver_type
+
+{- The `rec` type here doesn't properly constrain types assigned to `R` to only
+   be infinitely recursive as so far we simply let `rec` unify with everything.
+   I think we might want to consider treating `rec` in some positions to unify/4
+   as a particular bound.
+ -}
+type r = R receiver int (fn int -> rec)
+type s = S receiver int (fn int -> int)
+
+let adder_cell x =
+  receive with
+    y -> adder_cell (y + x)
+
+let main () = R adder_cell
+
+let one_receive x =
+  receive with
+    y -> x + y
+
+let use_s () = S one_receive


### PR DESCRIPTION
Makes both `receiver` and `rec` expressible but as the latter is
permitted to unify with anything it does not yet properly restrict
unification.