### PR TITLE
Generate test/0 for EUnit

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -473,4 +473,10 @@ receiver_type_test() ->
     [M] = compile_and_load(Files, []),
     code:delete(M).
 
+failing_test_test() ->
+    Files = ["test_files/failing_test.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(error, M:test()),
+    code:delete(M).
+
 -endif.

--- a/test_files/failing_test.alp
+++ b/test_files/failing_test.alp
@@ -1,0 +1,13 @@
+module failing_test
+
+export double
+
+let double x = x + x
+
+let assert_equal x y =
+  match x == y with
+    | true -> true
+    | false -> throw (:not_equal, x, y)
+
+test "fails" =
+  assert_equal (double 2) 5


### PR DESCRIPTION
Generates the `test/0` function that including the EUnit header in an
Erlang file normally does.  Just calls eunit:test(ModuleName) as the
`test/0` that comes from including EUnit.