### PR TITLE
Native symbols

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -187,7 +187,7 @@ private_types_error_test() ->
     Code = load_files(Files),
     {ok, Mods} = alpaca_ast_gen:make_modules(Code),
     ?assertEqual(
-       {error, {unexported_type, list_opts, basic_adt, "my_list"}},
+       {error, {unexported_type, list_opts, basic_adt, <<"my_list">>}},
        type_modules(Mods)).
 
 basic_pid_test() ->

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -425,7 +425,6 @@
                          | alpaca_binding()
                          | alpaca_type_check()
                          | alpaca_binding()
-                         | alpaca_fun_def()
                          | alpaca_type_import()
                          | alpaca_type_export()
                          | alpaca_error().
@@ -499,15 +498,6 @@
           body=undefined :: undefined | alpaca_expression()
          }).
 -type alpaca_binding() :: #alpaca_binding{}.
-
--record (alpaca_fun_def, {
-           type=undefined :: typ(),
-           name=undefined :: undefined|alpaca_symbol(),
-           arity=0 :: integer(),
-           versions=[] :: list(#alpaca_fun_version{})
-          }).
-
--type alpaca_fun_def() :: #alpaca_fun_def{}.
 
 -record(alpaca_type_import, {module=undefined :: atom(),
                            type=undefined :: string()}).

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -446,7 +446,7 @@ rebind_args(#env{current_module=Mod}=Env, Map, Args) ->
                 L = alpaca_ast:line(S),
                 case maps:get(N, AccMap, undefined) of
                     undefined ->
-                        Synth = unicode:characters_to_binary(next_var(NV), utf8),
+                        Synth = next_var(NV),
                         { E#env{next_var=NV+1}
                         , maps:put(N, Synth, AccMap)
                         , [alpaca_ast:symbol(L, Synth)|Syms]
@@ -471,9 +471,7 @@ rename_bindings(#env{current_module=Mod}=StartEnv, M,
     {NewName, En2, M2} = case maps:get(Name, M, undefined) of
                               undefined ->
                                  #env{next_var=NV} = StartEnv,
-                                 Synth = unicode:characters_to_binary(
-                                           next_var(NV),
-                                           utf8),
+                                 Synth = next_var(NV),
                                  E2 = StartEnv#env{next_var=NV+1},
                                  {Synth, E2, maps:put(Name, Synth, M)};
                              _ ->
@@ -816,7 +814,7 @@ make_bindings(#env{current_module=Mod}=Env, M, {'Symbol', _}=S) ->
     case maps:get(Name, M, undefined) of
         undefined ->
             #env{next_var=NV} = Env,
-            Synth = unicode:characters_to_binary(next_var(NV), utf8),
+            Synth = next_var(NV),
             Env2 = Env#env{next_var=NV+1},
             {Env2, maps:put(Name, Synth, M), alpaca_ast:symbol_rename(S, Synth)};
         _ ->
@@ -827,7 +825,7 @@ make_bindings(Env, M, Expression) ->
 
 -define(base_var_name, "svar_").
 next_var(X) ->
-    ?base_var_name ++ integer_to_list(X).
+    unicode:characters_to_binary(?base_var_name ++ integer_to_list(X), utf8).
 
 -ifdef(TEST).
 

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -42,10 +42,10 @@
           synthetic_fun_num=0 :: integer()
          }).
 
-name_and_arity(#alpaca_binding{name={_, _, N}, bound_expr=#alpaca_fun{arity=A}}) ->
-    {N, A};
-name_and_arity(#alpaca_binding{name={_, _, N}}) ->
-    {N, 0}.
+name_and_arity(#alpaca_binding{name={'Symbol', _}=S, bound_expr=#alpaca_fun{arity=A}}) ->
+    {alpaca_ast:symbol_name(S), A};
+name_and_arity(#alpaca_binding{name={'Symbol', _}=S}) ->
+    {alpaca_ast:symbol_name(S), 0}.
 
 make_env(#alpaca_module{functions=Funs}=_Mod) ->
     TopLevelFuns = [name_and_arity(F) || F <- Funs],
@@ -74,8 +74,8 @@ gen(#alpaca_module{}=Mod, Opts) ->
         [gen_export(E) || E <- Exports] ++ gen_test_exports(Tests, Opts, []),
     {ok, cerl:c_module(
            cerl:c_atom(PrefixModuleName),
-           [gen_export({"module_info", 0}),
-            gen_export({"module_info", 1})] ++
+           [gen_export({<<"module_info">>, 0}),
+            gen_export({<<"module_info">>, 1})] ++
                CompiledExports,
            [],
            [module_info0(PrefixModuleName),
@@ -115,7 +115,7 @@ rewrite_lambdas(#alpaca_fun_version{body=B}=FV, NextFun, _) ->
     {NF2, B2, NewBinds} = rewrite_lambdas(B, NextFun, []),
 
     F = fun({Name, Exp}, Chain) ->
-                {symbol, L, _} = Name,
+                L = alpaca_ast:line(Name),
                 #alpaca_binding{name=Name,
                                 line=L,
                                 bound_expr=Exp,
@@ -126,9 +126,10 @@ rewrite_lambdas(#alpaca_fun_version{body=B}=FV, NextFun, _) ->
     {NF2, FV#alpaca_fun_version{body=Rebound}, []};
 rewrite_lambdas(#alpaca_fun{line=L, versions=Vs}=Fun, NextFun, Memo) ->
     {NextFun2, VMemo, BMemo} = rewrite_seq_lambdas(Vs, NextFun),
-    FunName = {symbol, L, ":synth_lambda_" ++ integer_to_list(NextFun2)},
+    FunName = ":synth_lambda_" ++ integer_to_list(NextFun2),
+    FunSym = alpaca_ast:symbol(L, unicode:characters_to_binary(FunName, utf8)),
     Fun2 = Fun#alpaca_fun{versions=VMemo},
-    {NextFun2, FunName, [{FunName, Fun2} | [BMemo | Memo]]};
+    {NextFun2, FunSym, [{FunSym, Fun2} | [BMemo | Memo]]};
 rewrite_lambdas(#alpaca_binding{bound_expr=BE, body=Body}=AB, NextFun, Memo) ->
     {NextFun2, BE2, Binds} = case BE of
                                  #alpaca_fun{versions=Vs}=Fun ->
@@ -151,12 +152,12 @@ rewrite_lambdas(X, NextFun, Memo) ->
     {NextFun, X, Memo}.
 
 gen_export({N, A}) ->
-    cerl:c_fname(list_to_atom(N), A).
+    cerl:c_fname(binary_to_atom(N, utf8), A).
 
 gen_test_exports([], _, Memo) ->
-    [gen_export({"test", 0})|Memo];
+    [gen_export({<<"test">>, 0})|Memo];
 gen_test_exports(_, [], Memo) ->
-    [gen_export({"test", 0})|Memo];
+    [gen_export({<<"test">>, 0})|Memo];
 gen_test_exports([#alpaca_test{name={string, _, N}}|RemTests], [test|_]=Opts,
                  Memo) ->
     gen_test_exports(
@@ -172,21 +173,24 @@ gen_funs(Env, Funs, [#alpaca_binding{}=F|T]) ->
 
 gen_fun(Env,
         #alpaca_binding{
-           name={symbol, _, N},
+           name={'Symbol', _}=Sym,
            bound_expr=#alpaca_fun{
                          versions=[#alpaca_fun_version{args=[{unit, _}], body=Body}]}}) ->
-
-    FName = cerl:c_fname(list_to_atom(N), 1),
+    N = alpaca_ast:symbol_name(Sym),
+    FName = cerl:c_fname(binary_to_atom(N, utf8), 1),
     A = [cerl:c_var('_unit')],
     {_, B} = gen_expr(Env, Body),
     {FName, cerl:c_fun(A, B)};
-gen_fun(Env, #alpaca_binding{name={symbol, _, N}, bound_expr=Bound}) ->
+gen_fun(Env, #alpaca_binding{name={'Symbol', _}=Sym, bound_expr=Bound}) ->
+    N = alpaca_ast:symbol_name(Sym),
     case Bound of
         #alpaca_fun{versions=[#alpaca_fun_version{args=Args, body=Body}]}=Def ->
             case needs_pattern(Args) of
                 false ->
-                    FName = cerl:c_fname(list_to_atom(N), length(Args)),
-                    A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
+                    FName = cerl:c_fname(binary_to_atom(N, utf8), length(Args)),
+                    A = [cerl:c_var(binary_to_atom(X, utf8)) ||
+                            {'Symbol', #{name := X}} <- Args
+                        ],
                     {_, B} = gen_expr(Env, Body),
                     {FName, cerl:c_fun(A, B)};
                 true ->
@@ -197,14 +201,14 @@ gen_fun(Env, #alpaca_binding{name={symbol, _, N}, bound_expr=Bound}) ->
             %% more than one version:
             gen_fun_patterns(Env, N, Def);
         NotFunction ->
-            FName = cerl:c_fname(list_to_atom(N), 0),
+            FName = cerl:c_fname(binary_to_atom(N, utf8), 0),
             {_, B} = gen_expr(Env, NotFunction),
             {FName, cerl:c_fun([], B)}
     end.
 
 needs_pattern(Args) ->
     case lists:filter(fun({unit, _})      -> false;
-                         ({symbol, _, _}) -> false;
+                         ({'Symbol', _}) -> false;
                          (_)              -> true
                       end, Args) of
         [] -> false;
@@ -245,7 +249,7 @@ gen_tests(#env{prefixed_module=PM}, [], Memo) ->
 gen_tests(Env, [#alpaca_test{name={_, _, N}, expression=E}|Rem], Memo) ->
     FName = cerl:c_fname(list_to_atom(clean_test_name(N)), 0),
     {_, Body} = gen_expr(Env, E),
-    TestFun = {FName, cerl:c_fun([], Body)},
+    TestFun = {utf8_bin(FName), cerl:c_fun([], Body)},
     gen_tests(Env, Rem, [TestFun|Memo]).
 
 %% eunit will skip tests with spaces in the name, this may not be the best
@@ -253,6 +257,9 @@ gen_tests(Env, [#alpaca_test{name={_, _, N}, expression=E}|Rem], Memo) ->
 clean_test_name(N) ->
     Base = lists:map(fun(32) -> 95; (C) -> C end, N),
     Base ++ "_test".
+
+utf8_bin(S) when is_list(S) ->
+    unicode:characters_to_binary(S, utf8).
 
 gen_expr(Env, {add, _}) ->
     {Env, cerl:c_atom('+')};
@@ -278,21 +285,22 @@ gen_expr(#env{wildcard_num=N}=Env, {'_', _}) ->
     %% compiling forms later due to duplicate names.
     Name = list_to_atom("_" ++ integer_to_list(N)),
     {Env#env{wildcard_num=N+1}, cerl:c_var(Name)};
-gen_expr(#env{module_funs=Funs}=Env, {symbol, _, V}) ->
+gen_expr(#env{module_funs=Funs}=Env, {'Symbol', _}=Sym) ->
+    V = alpaca_ast:symbol_name(Sym),
     case proplists:get_value(V, Funs) of
         %% Switch out references to zero-arg funs to applications
         %% of them, simulating constant values
         0 ->
-            {Env, cerl:c_apply(cerl:c_fname(list_to_atom(V), 0), [])};
+            {Env, cerl:c_apply(cerl:c_fname(binary_to_atom(V, utf8), 0), [])};
         Arity when is_integer(Arity) ->
             %% Do we have a function with the right arity?
-            {Env, cerl:c_fname(list_to_atom(V), Arity)};
+            {Env, cerl:c_fname(binary_to_atom(V, utf8), Arity)};
         undefined ->
-            {Env, cerl:c_var(list_to_atom(V))}
+            {Env, cerl:c_var(binary_to_atom(V, utf8))}
     end;
 gen_expr(Env, #alpaca_far_ref{module=M, name=N, arity=A}) ->
     MakeFun = #alpaca_apply{
-                 expr={'erlang', {symbol, 0, "make_fun"}, 3},
+                 expr={'erlang', alpaca_ast:symbol(0, <<"make_fun">>), 3},
                  args=[{atom, 0, "alpaca_" ++ atom_to_list(M)},
                        {atom, 0, N},
                        alpaca_ast:int(0, A)]},
@@ -368,15 +376,15 @@ gen_expr(Env, #alpaca_record_transform{additions=Adds, existing=Existing}) ->
              cerl:c_atom(put),
              [KExp, VExp, RecExp])};
 
-gen_expr(Env, #alpaca_type_check{type=is_string, expr={symbol, _, _}=S}) ->
+gen_expr(Env, #alpaca_type_check{type=is_string, expr={'Symbol', _}=S}) ->
     {_, Exp} = gen_expr(Env, S),
     TC = cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom('is_binary'), [Exp]),
     {Env, TC};
-gen_expr(Env, #alpaca_type_check{type=is_chars, expr={symbol, _, _}=S}) ->
+gen_expr(Env, #alpaca_type_check{type=is_chars, expr={'Symbol', _}=S}) ->
     {_, Exp} = gen_expr(Env, S),
     TC = cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom('is_list'), [Exp]),
     {Env, TC};
-gen_expr(Env, #alpaca_type_check{type=T, expr={symbol, _, _}=S}) ->
+gen_expr(Env, #alpaca_type_check{type=T, expr={'Symbol', _}=S}) ->
     {_, Exp} = gen_expr(Env, S),
     TC = cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom(T), [Exp]),
     {Env, TC};
@@ -386,44 +394,55 @@ gen_expr(Env, #alpaca_apply{expr={bif, _, _L, Module, FName}, args=Args}) ->
               cerl:c_atom(FName),
               [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
     {Env, Apply};
-gen_expr(Env, #alpaca_apply{expr={Module, {symbol, _L, N}, _}, args=Args}) ->
+gen_expr(Env, #alpaca_apply{expr={Module, {'Symbol', _}=Sym, _}, args=Args}) ->
+    N = binary_to_atom(alpaca_ast:symbol_name(Sym), utf8),
     FName = cerl:c_atom(N),
     Apply = cerl:c_call(
               cerl:c_atom(prefix_modulename(Module)),
               FName,
               [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
     {Env, Apply};
-gen_expr(Env, #alpaca_apply{expr={symbol, _Line, Name}, args=[{unit, _}]}) ->
+gen_expr(Env, #alpaca_apply{expr={'Symbol', _}=Sym, args=[{unit, _}]}) ->
+    Name = alpaca_ast:symbol_name(Sym),
     FName = case proplists:get_value(Name, Env#env.module_funs) of
-                undefined -> cerl:c_var(list_to_atom(Name));
-                1 -> cerl:c_fname(list_to_atom(Name), 1)
+                undefined -> cerl:c_var(binary_to_atom(Name, utf8));
+                1 -> cerl:c_fname(binary_to_atom(Name, utf8), 1)
             end,
     {Env, cerl:c_apply(FName, [cerl:c_atom(unit)])};
-gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
+gen_expr(Env, #alpaca_apply{expr={'Symbol', _}=FExpr, args=Args}) ->
+    L = alpaca_ast:line(FExpr),
+    Name = alpaca_ast:symbol_name(FExpr),
     DesiredArity = length(Args),
     {FName, Curry, Arity} = case proplists:get_all_values(Name, Env#env.module_funs) of
-        [] -> {cerl:c_var(list_to_atom(Name)), false, 0};
+        [] -> {cerl:c_var(binary_to_atom(Name, utf8)), false, 0};
         AvailFuns ->
             %% If we have an exact arity match, use that, otherwise curry
             case lists:filter(fun(X) -> X =:= DesiredArity end, AvailFuns) of
-                [A] -> {cerl:c_fname(list_to_atom(Name), A), false, A};
+                [A] -> {cerl:c_fname(binary_to_atom(Name, utf8), A), false, A};
                 _ ->
                     %% The typer ensures that we can curry unambiguously
-                    [CurryArity] = lists:filter(fun(X) -> X > DesiredArity end, AvailFuns),
-                    {cerl:c_fname(list_to_atom(Name), CurryArity), true, CurryArity}
+                    [CurryArity] = lists:filter(
+                                     fun(X) -> X > DesiredArity end,
+                                     AvailFuns),
+                    {cerl:c_fname(binary_to_atom(Name, utf8), CurryArity),
+                     true,
+                     CurryArity}
             end
     end,
     case Curry of
         true -> %% generate an anonymous fun
-           CurryFunName = "curry_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
-           Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
-           CArgs = lists:map(
-               fun(A) ->
-                    {symbol, L, "carg_" ++ integer_to_list(A)}
-               end,
-               lists:seq(DesiredArity+1, Arity)),
-           CurryExpr = #alpaca_fun{
-                          arity=Arity-DesiredArity,
+            CFString = "curry_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
+            CurryFunName = utf8_bin(CFString),
+            Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
+            CArgs = lists:map(
+                      fun(A) ->
+                              alpaca_ast:symbol(
+                                L,
+                                utf8_bin("carg_" ++ integer_to_list(A)))
+                      end,
+                      lists:seq(DesiredArity+1, Arity)),
+            CurryExpr = #alpaca_fun{
+                           arity=Arity-DesiredArity,
                           versions=[#alpaca_fun_version{
                                        args=CArgs,
                                        body=#alpaca_apply{
@@ -431,8 +450,8 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
                                                expr=FExpr,
                                                args=Args ++ CArgs}}]},
            Binding = #alpaca_binding{
-                        name={symbol, L, CurryFunName},
-                        body={symbol, L, CurryFunName},
+                        name=alpaca_ast:symbol(L, CurryFunName),
+                        body=alpaca_ast:symbol(L, CurryFunName),
                         bound_expr=CurryExpr},
 
            gen_expr(Env2, Binding);
@@ -443,21 +462,23 @@ gen_expr(Env, #alpaca_apply{expr={symbol, L, Name}=FExpr, args=Args}) ->
                         [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
                         {Env, Apply}
     end;
-gen_expr(Env, #alpaca_apply{expr={{symbol, _L, N}, Arity}, args=Args}) ->
-    FName = cerl:c_fname(list_to_atom(N), Arity),
+gen_expr(Env, #alpaca_apply{expr={{'Symbol', _}=Sym, Arity}, args=Args}) ->
+    N = alpaca_ast:symbol_name(Sym),
+    FName = cerl:c_fname(binary_to_atom(N, utf8), Arity),
     Apply = cerl:c_apply(
               FName,
               [A || {_, A} <- [gen_expr(Env, E) || E <- Args]]),
     {Env, Apply};
 gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
-    FunName = "synth_fun_" ++ integer_to_list(Env#env.synthetic_fun_num),
+    FunName = utf8_bin("synth_fun_" ++ integer_to_list(Env#env.synthetic_fun_num)),
     Env2 = Env#env{synthetic_fun_num=Env#env.synthetic_fun_num + 1},
     case Expr of
         %% Detect far refs that require currying
         #alpaca_far_ref{arity=Arity} when Arity > length(Args) ->
             CArgs = lists:map(
                fun(A) ->
-                    {symbol, L, "carg_" ++ integer_to_list(A)}
+                       Name = utf8_bin("carg_" ++ integer_to_list(A)),
+                       alpaca_ast:symbol(L, Name)
                end,
                lists:seq(length(Args)+1, Arity)),
                CurryExpr = #alpaca_fun{
@@ -469,16 +490,17 @@ gen_expr(Env, #alpaca_apply{line=L, expr=Expr, args=Args}) ->
                                             expr=Expr,
                                             args=Args ++ CArgs}}]},
                Binding = #alpaca_binding{
-                            name={symbol, L, FunName},
-                            body={symbol, L, FunName},
+                            name=alpaca_ast:symbol(L, FunName),
+                            body=alpaca_ast:symbol(L, FunName),
                             bound_expr=CurryExpr},
                gen_expr(Env2, Binding);
         _ ->
             SynthBinding = #alpaca_binding{
-                              name={symbol, L, FunName},
+                              name=alpaca_ast:symbol(L, FunName),
                               bound_expr=Expr,
                               body=#alpaca_apply{
-                                      line=L, expr={symbol, L, FunName},
+                                      line=L,
+                                      expr=alpaca_ast:symbol(L, FunName),
                                       args=Args}},
 
             gen_expr(Env2, SynthBinding)
@@ -543,9 +565,9 @@ gen_expr(Env, #alpaca_match{match_expr=Exp, clauses=Cs}) ->
 
 gen_expr(Env, #alpaca_spawn{from_module=M,
                           module=undefined,
-                          function={symbol, _, FN},
+                          function={'Symbol', _}=Sym,
                           args=Args}) ->
-
+    FN = binary_to_atom(alpaca_ast:symbol_name(Sym), utf8),
     ArgCons = lists:foldl(fun(A, L) ->
                                   {_, AExp} = gen_expr(Env, A),
                                   cerl:c_cons(AExp, L)
@@ -583,7 +605,8 @@ gen_expr(Env, #alpaca_send{message=M, pid=P}) ->
     {Env, cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom('!'), [PExp, MExp])};
 
 gen_expr(#env{module_funs=Funs}=Env, #alpaca_binding{}=AB) ->
-    #alpaca_binding{name={symbol, _, N}, bound_expr=BE, body=Body} = AB,
+    #alpaca_binding{name={'Symbol', _}=Sym, bound_expr=BE, body=Body} = AB,
+    N = alpaca_ast:symbol_name(Sym),
     case BE of
         #alpaca_fun{arity=Arity} ->
             NewEnv = Env#env{module_funs=[{N, Arity}|Funs]},
@@ -601,7 +624,10 @@ gen_expr(#env{module_funs=Funs}=Env, #alpaca_binding{}=AB) ->
                 _ ->
                     {_, E1Exp} = gen_expr(Env, BE),
                     {_, E2Exp} = gen_expr(Env, Body),
-                    {Env, cerl:c_let([cerl:c_var(list_to_atom(N))], E1Exp, E2Exp)}
+                    {Env,
+                     cerl:c_let([cerl:c_var(binary_to_atom(N, utf8))],
+                                E1Exp,
+                                E2Exp)}
             end
     end.
 

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -117,42 +117,43 @@ comment -> comment_lines :
                 text=Chars}.
 
 type_import -> import_type symbol '.' symbol:
-  {symbol, _, Mod} = '$2',
-  {symbol, _, Type} = '$4',
-  #alpaca_type_import{module=list_to_atom(Mod), type=Type}.
+  Mod = symbol_name('$2'),
+  Type = symbol_name('$4'),
+  #alpaca_type_import{module=binary_to_atom(Mod, utf8), type=Type}.
 
-types_to_export -> symbol : ['$1'].
-types_to_export -> symbol ',' types_to_export : ['$1'|'$3'].
+types_to_export -> symbol : [unwrap('$1')].
+types_to_export -> symbol ',' types_to_export : [unwrap('$1')|'$3'].
 
 type_export -> export_type types_to_export :
   {_, L}  = '$1',
-  Names = [N || {symbol, _, N} <- '$2'],
+  Names = [symbol_name(S) || S <- '$2'],
   #alpaca_type_export{line=L, names=Names}.
 
 type_expressions -> sub_type_expr : ['$1'].
 type_expressions -> sub_type_expr type_expressions : ['$1'|'$2'].
 
 poly_type -> symbol type_expressions :
-  {symbol, L, N} = '$1',
+  {L, N} = symbol_line_name('$1'),
+
   Members = '$2',
 
   case {N, Members} of
-      {"atom", Params}           -> type_arity_error(L, t_atom, Params);
-      {"binary", Params}         -> type_arity_error(L, t_binary, Params);
-      {"bool", Params}           -> type_arity_error(L, t_bool, Params);
-      {"chars", Params}          -> type_arity_error(L, t_chars, Params);
-      {"float", Params}          -> type_arity_error(L, t_float, Params);
-      {"int", Params}            -> type_arity_error(L, t_int, Params);
-      {"list", [E]}              -> {t_list, E};
-      {"list", Params}           -> type_arity_error(L, t_list, Params);
-      {"map", [K, V]}            -> {t_map, K, V};
-      {"map", Params}            -> type_arity_error(L, t_map, Params);
-      {"receiver", [MsgT, ExpT]} -> {t_receiver, MsgT, ExpT};
-      {"receiver", Params}       -> type_arity_error(L, t_receiver, Params);
-      {"pid", [T]}               -> {t_pid, T};
-      {"pid", Params}            -> type_arity_error(L, t_pid, Params);
-      {"string", Params}         -> type_arity_error(L, t_string, Params);
-      {"rec", Params}            -> type_arity_error(L, t_rec, Params);
+      {<<"atom">>, Params}           -> type_arity_error(L, t_atom, Params);
+      {<<"binary">>, Params}         -> type_arity_error(L, t_binary, Params);
+      {<<"bool">>, Params}           -> type_arity_error(L, t_bool, Params);
+      {<<"chars">>, Params}          -> type_arity_error(L, t_chars, Params);
+      {<<"float">>, Params}          -> type_arity_error(L, t_float, Params);
+      {<<"int">>, Params}            -> type_arity_error(L, t_int, Params);
+      {<<"list">>, [E]}              -> {t_list, E};
+      {<<"list">>, Params}           -> type_arity_error(L, t_list, Params);
+      {<<"map">>, [K, V]}            -> {t_map, K, V};
+      {<<"map">>, Params}            -> type_arity_error(L, t_map, Params);
+      {<<"receiver">>, [MsgT, ExpT]} -> {t_receiver, MsgT, ExpT};
+      {<<"receiver">>, Params}       -> type_arity_error(L, t_receiver, Params);
+      {<<"pid">>, [T]}               -> {t_pid, T};
+      {<<"pid">>, Params}            -> type_arity_error(L, t_pid, Params);
+      {<<"string">>, Params}         -> type_arity_error(L, t_string, Params);
+      {<<"rec">>, Params}            -> type_arity_error(L, t_rec, Params);
       _ ->
           %% Any concrete type in the type_expressions gets a synthesized variable name:
           Vars = make_vars_for_concrete_types('$2', L),
@@ -164,9 +165,9 @@ poly_type -> symbol type_expressions :
              vars = Vars}
   end.
 
-record_type_member -> symbol ':' type_expr : 
-  {symbol, _L, N} = '$1',
-  #t_record_member{name=list_to_atom(N), type='$3'}.
+record_type_member -> symbol ':' type_expr :
+  N = symbol_name('$1'),
+  #t_record_member{name=binary_to_atom(N, utf8), type='$3'}.
 
 record_type_members -> record_type_member : ['$1'].
 record_type_members -> record_type_member ',' record_type_members : ['$1' | '$3'].
@@ -175,15 +176,15 @@ record_type -> open_brace record_type_members close_brace :
   #t_record{members='$2'}.
 
 module_qualified_type_name -> symbol '.' symbol:
-  {symbol, L, Mod} = '$1',
-  {symbol, _, Name} = '$3',
+  {L, Mod} = symbol_line_name('$1'),
+  Name = symbol_name('$3'),
   {module_qualified_type_name, L, Mod, Name}.
 
 module_qualified_type -> module_qualified_type_name :
   {module_qualified_type_name, L, Mod, Name} = '$1',
   #alpaca_type{
      line = L,
-     module = list_to_atom(Mod),
+     module = binary_to_atom(Mod, utf8),
      name = {type_name, L, Name}}.
 
 module_qualified_type -> module_qualified_type_name type_expressions:
@@ -193,7 +194,7 @@ module_qualified_type -> module_qualified_type_name type_expressions:
 
   #alpaca_type{
      line = L,
-     module = list_to_atom(Mod),
+     module = binary_to_atom(Mod, utf8),
      name = {type_name, L, Name},
      vars = Vars}.
 
@@ -204,29 +205,30 @@ type_expr -> sub_type_expr : '$1'.
 sub_type_expr -> type_var : '$1'.
 sub_type_expr -> record_type : '$1'.
 sub_type_expr -> symbol :
-  {symbol, L, N} = '$1',
+  {L, N} = symbol_line_name('$1'),
+
   case N of
-      "atom" ->
+      <<"atom">> ->
           t_atom;
-      "binary" ->
+      <<"binary">> ->
           t_binary;
-      "bool" ->
+      <<"bool">> ->
           t_bool;
-      "chars" ->
+      <<"chars">> ->
           t_chars;
-      "float" ->
+      <<"float">> ->
           t_float;
-      "int" ->
+      <<"int">> ->
           t_int;
-      "list" ->
+      <<"list">> ->
           return_error(L, {wrong_type_arity, t_list, 0});
-      "map" ->
+      <<"map">> ->
           return_error(L, {wrong_type_arity, t_map, 0});
-      "pid" ->
+      <<"pid">> ->
           return_error(L, {wrong_type_arity, t_pid, 0});
-      "string" ->
+      <<"string">> ->
           t_string;
-      "rec" ->
+      <<"rec">> ->
           t_rec;
       _ ->
           #alpaca_type{name={type_name, L, N}, vars=[]} % not polymorphic
@@ -273,7 +275,7 @@ type_members -> type_member '|' type_members : ['$1'|'$3'].
 type -> type_declare poly_type_decl assign type_members :
   '$2'#alpaca_type{members='$4'}.
 type -> type_declare symbol assign type_members :
-  {symbol, L, N} = '$2',
+  {L, N} = symbol_line_name('$2'),
   #alpaca_type{
      line=L,
      name={type_name, L, N},
@@ -281,7 +283,7 @@ type -> type_declare symbol assign type_members :
      members='$4'}.
 
 poly_type_decl -> symbol type_vars :
-  {symbol, L, N} = '$1',
+  {L, N} = symbol_line_name('$1'),
   #alpaca_type{
      line=L,
      name={type_name, L, N},
@@ -291,9 +293,9 @@ type_vars -> type_var : ['$1'].
 type_vars -> type_var type_vars : ['$1'|'$2'].
 
 module_qualified_type_constructor -> symbol '.' type_constructor :
-  {symbol, _, Mod} = '$1',
+  Mod = symbol_name('$1'),
   {type_constructor, L, N} = '$3',
-  #type_constructor{line=L, module=list_to_atom(Mod), name=N}.
+  #type_constructor{line=L, module=binary_to_atom(Mod, utf8), name=N}.
 
 type_apply -> module_qualified_type_constructor term :
   #alpaca_type_apply{name='$1', arg='$2'}.
@@ -344,14 +346,18 @@ const -> '_' : '$1'.
 const -> unit : '$1'.
 
 module_fun -> symbol '.' symbol '/' int :
-  {symbol, L, Mod} = '$1',
-  {symbol, _, Fun} = '$3',
+  {L, Mod} = symbol_line_name('$1'),
+  Fun = symbol_name('$3'),
   {int, _, Arity} = '$5',
-  #alpaca_far_ref{line=L, module=list_to_atom(Mod), name=Fun, arity=Arity}.
+  #alpaca_far_ref{
+     line=L,
+     module=binary_to_atom(Mod, utf8),
+     name=Fun,
+     arity=Arity}.
 module_fun -> symbol '.' symbol :
-  {symbol, L, Mod} = '$1',
-  {symbol, _, Fun} = '$3',
-  #alpaca_far_ref{line=L, module=list_to_atom(Mod), name=Fun}.
+  {L, Mod} = symbol_line_name('$1'),
+  Fun = symbol_name('$3'),
+  #alpaca_far_ref{line=L, module=binary_to_atom(Mod, utf8), name=Fun}.
 
 %% ----- Lists  ------------------------
 literal_cons_items -> term : ['$1'].
@@ -370,38 +376,38 @@ cons -> '[' literal_cons_items ']':
 
 %% -----  Binaries  --------------------
 bin_qualifier -> type_declare assign symbol :
-    {symbol, L, S} = '$3',
+    {L, S} = symbol_line_name('$3'),
     case S of
-        "binary" -> {bin_type, S};
-        "float" -> {bin_type, S};
-        "int" -> {bin_type, S};
-        "utf8" -> {bin_type, S};
+        <<"binary">> -> {bin_type, S};
+        <<"float">> -> {bin_type, S};
+        <<"int">> -> {bin_type, S};
+        <<"utf8">> -> {bin_type, S};
         _      -> return_error(L, {invalid_bin_type, S})
     end.
 bin_qualifier -> symbol assign int :
-    {symbol, L, S} = '$1',
+    {L, S} = symbol_line_name('$1'),
     case S of
-        "size" -> {size, '$3'};
-        "unit" -> {unit, '$3'};
-        _      -> return_error(L, {invalid_bin_qualifier, S})
+        <<"size">> -> {size, '$3'};
+        <<"unit">> -> {unit, '$3'};
+        _          -> return_error(L, {invalid_bin_qualifier, S})
     end.
 bin_qualifier -> symbol assign boolean :
-    {symbol, L, S} = '$1',
+    {L, S} = symbol_line_name('$1'),
     case {S, '$3'} of
-        {"sign", {boolean, L, true}}  -> {bin_sign, L, "signed"};
-        {"sign", {boolean, L, false}} -> {bin_sign, L, "unsigned"};
+        {<<"sign">>, {boolean, L, true}}  -> {bin_sign, L, <<"signed">>};
+        {<<"sign">>, {boolean, L, false}} -> {bin_sign, L, <<"unsigned">>};
         {_, _}                        ->
             return_error(L, {invalid_bin_qualifier, S})
     end.
 bin_qualifier -> symbol assign symbol :
-    {symbol, _, K} = '$1',
-    {symbol, L, V} = '$3',
+    K = symbol_name('$1'),
+    {L, V} = symbol_line_name('$3'),
     case {K, V} of
-        {"end", "big"}    -> {bin_endian, L, V};
-        {"end", "little"} -> {bin_endian, L, V};
-        {"end", "native"} -> {bin_endian, L, V};
-        {"end", _}        -> return_error(L, {invalid_endianess, V});
-        {_, _}            -> return_error(L, {invalid_bin_qualifier, V})
+        {<<"end">>, <<"big">>}    -> {bin_endian, L, V};
+        {<<"end">>, <<"little">>} -> {bin_endian, L, V};
+        {<<"end">>, <<"native">>} -> {bin_endian, L, V};
+        {<<"end">>, _}            -> return_error(L, {invalid_endianess, V});
+        {_, _}                    -> return_error(L, {invalid_bin_qualifier, V})
     end.
 
 bin_qualifiers -> bin_qualifier : ['$1'].
@@ -413,7 +419,8 @@ bin_segment -> float :
 bin_segment -> int :
   {int, L, V} = '$1',
   #alpaca_bits{value=alpaca_ast:int(L, V), type=int, line=term_line('$1')}.
-bin_segment -> symbol : #alpaca_bits{value='$1', line=term_line('$1')}.
+bin_segment -> symbol :
+  #alpaca_bits{value=unwrap('$1'), line=line(unwrap('$1'))}.
 bin_segment -> binary : #alpaca_bits{value='$1', line=term_line('$1'), type=binary}.
 bin_segment -> string : #alpaca_bits{value='$1', line=term_line('$1'), type=utf8}.
 %% TODO:  string bin_segment
@@ -444,8 +451,8 @@ map_add -> map_open map_pair '|' term close_brace:
   #alpaca_map_add{line=term_line('$1'), to_add='$2', existing='$4'}.
 
 record_member -> symbol assign simple_expr:
-  {symbol, L, N} = '$1',
-  #alpaca_record_member{line=L, name=list_to_atom(N), val='$3'}.
+  {L, N} = symbol_line_name('$1'),
+  #alpaca_record_member{line=L, name=binary_to_atom(N, utf8), val='$3'}.
 
 record_members -> record_member: ['$1'].
 record_members -> record_member ',' record_members: ['$1' | '$3'].
@@ -509,7 +516,7 @@ term -> literal_fun : '$1'.
 term -> const : '$1'.
 term -> tuple : '$1'.
 term -> infix : '$1'.
-term -> symbol : '$1'.
+term -> symbol : unwrap('$1').
 term -> cons : '$1'.
 term -> binary : '$1'.
 term -> map_literal : '$1'.
@@ -526,7 +533,7 @@ terms -> term terms : ['$1'|'$2'].
 
 type_check -> type_check_tok symbol :
   {_, Check, L} = '$1',
-  #alpaca_type_check{type=Check, line=L, expr='$2'}.
+  #alpaca_type_check{type=Check, line=L, expr=unwrap('$2')}.
 
 compare -> eq : '$1'.
 compare -> neq : '$1'.
@@ -573,14 +580,19 @@ spawn_pid -> spawn symbol terms:
   {_, L} = '$1',
   #alpaca_spawn{line=L,
               module=undefined,
-              function='$2',
+              function=unwrap('$2'),
               args='$3'}.
 
 defn -> let terms assign simple_expr : make_define('$2', '$4', 'top').
 
 definfix -> let '(' infixable ')' terms assign simple_expr : 
   {infixable, L, C} = '$3',
-  make_define([{symbol, L, "(" ++ C ++ ")"}] ++ '$5', '$7', 'top').
+  %% This conversion may seem excessive but note that the purpose of the Alpaca
+  %% native AST is to let Alpaca code work with the AST.  This means that symbol
+  %% names do need to be legitimate Alpaca strings in UTF-8, not Erlang strings.
+  BinC = unicode:characters_to_binary(C, utf8),
+  InfixName = <<"("/utf8, BinC/binary, ")"/utf8>>,
+  make_define([alpaca_ast:symbol(L, InfixName) | '$5'], '$7', 'top').
 
 binding -> let defn in simple_expr : make_binding('$2', '$4').
 
@@ -595,8 +607,8 @@ ffi_call -> beam atom atom cons with match_clauses:
             clauses='$6'}.
 
 module_def -> module symbol :
-{symbol, L, Name} = '$2',
-{module, list_to_atom(Name), L}.
+{L, Name} = symbol_line_name('$2'),
+{module, binary_to_atom(Name, utf8), L}.
 
 export_def -> export export_list : {export, '$2'}.
 %% Imported functions come out of the parser in the following tuple format:
@@ -614,11 +626,11 @@ import_def -> import import_fun_items : {import, lists:flatten('$2')}.
 %% fun_list_items get turned into the correct tuple format above when they
 %% become a fun_subset (see a bit further below).
 fun_list_items -> import_export_fun :
-  {symbol, _, F} = '$1',
+  F = symbol_name('$1'),
   [F].
 fun_list_items -> fun_and_arity : ['$1'].
 fun_list_items -> import_export_fun ',' fun_list_items :
-  {symbol, _, F} = '$1',
+  F = symbol_name('$1'),
   [F | '$3'].
 fun_list_items -> fun_and_arity ',' fun_list_items : ['$1' | '$3'].
 
@@ -626,9 +638,9 @@ fun_list_items -> fun_and_arity ',' fun_list_items : ['$1' | '$3'].
 %% We do this so we can deal with a flat proplist later on when resolving 
 %% functions that aren't defined in the module importing these functions.
 fun_subset -> symbol '.' '[' fun_list_items ']' : 
-  {symbol, _, Mod} = '$1',
-  F = fun({Name, Arity}) -> {Name, {list_to_atom(Mod), Arity}};
-         (Name)          -> {Name, list_to_atom(Mod)}
+  Mod = binary_to_atom(symbol_name('$1'), utf8),
+  F = fun({Name, Arity}) -> {Name, {Mod, Arity}};
+         (Name)          -> {Name, Mod}
   end,
   lists:map(F, '$4').
 
@@ -636,41 +648,42 @@ fun_subset -> symbol '.' '[' fun_list_items ']' :
 
 %% module.foo means import all arities for foo:
 import_fun_item -> symbol '.' import_export_fun :
-  {symbol, _, Mod} = '$1',
-  {symbol, _, Fun} = '$3',
-  {Fun, list_to_atom(Mod)}.
+  Mod = symbol_name('$1'),
+  Fun = symbol_name('$3'),
+  {Fun, binary_to_atom(Mod, utf8)}.
 %% module.foo/1 means only import foo/1:
 import_fun_item -> symbol '.' import_export_fun '/' int:
-  {symbol, _, Mod} = '$1',
-  {symbol, _, Fun} = '$3',
+  Mod = symbol_name('$1'),
+  Fun = symbol_name('$3'),
   {int, _, Arity} = '$5',  
-  {Fun, {list_to_atom(Mod), Arity}}.
+  {Fun, {binary_to_atom(Mod, utf8), Arity}}.
 import_fun_item -> fun_subset : '$1'.
 
 import_fun_items -> import_fun_item : ['$1'].
 import_fun_items -> import_fun_item ',' import_fun_items : ['$1'|'$3'].
 
-import_export_fun -> symbol : '$1'.
+import_export_fun -> symbol : unwrap('$1').
 import_export_fun -> '(' infixable ')' :
   {infixable, L, C} = '$2',
-  {symbol, L, "(" ++ C ++ ")"}.
+  BinC = unicode:characters_to_binary(C, utf8),
+  alpaca_ast:symbol(L, <<"("/utf8, BinC/binary, ")"/utf8>>).
 
 fun_and_arity -> import_export_fun '/' int :
-  {symbol, _, Name} = '$1',
+  Name = symbol_name('$1'),
   {int, _, Arity} = '$3',
   {Name, Arity}.
 fun_and_arity -> symbol '/' int :
-{symbol, _, Name} = '$1',
+Name = symbol_name('$1'),
 {int, _, Arity} = '$3',
 {Name, Arity}.
 
 export_list -> fun_and_arity : ['$1'].
 export_list -> import_export_fun :
-  {_, _, Name} = '$1',
+  Name = symbol_name('$1'),
   [Name].
 export_list -> fun_and_arity ',' export_list : ['$1' | '$3'].
 export_list -> symbol ',' export_list :
-  {_, _, Name} = '$1',
+  Name = symbol_name('$1'),
   [Name | '$3'].
 
 %% TODO:  we should be able to apply the tail to the result of
@@ -680,10 +693,11 @@ simple_expr -> terms :
 case '$1' of
     [T] ->
         T;
-    [{symbol, L, _} = S | T] ->
-        #alpaca_apply{line=L, expr=S, args=T};
+    [{symbol, S} | T] ->
+        #alpaca_apply{line=line(S), expr=S, args=T};
     [#alpaca_far_ref{line=L, module=Mod, name=Fun} | T] ->
-        Name = {Mod, {symbol, L, Fun}, length(T)},
+        FunName = unicode:characters_to_binary(Fun, utf8),
+        Name = {Mod, alpaca_ast:symbol(L, FunName), length(T)},
         #alpaca_apply{line=L, expr=Name, args=T};
     [Term|Args] ->
         #alpaca_apply{line=term_line(Term), expr=Term, args=Args}
@@ -721,7 +735,9 @@ Erlang code.
 
 make_infix(Op, A, B) ->
     Name = case Op of
-      {infixable, L, C} -> {symbol, L, "(" ++ C ++ ")"};
+      {infixable, L, C} ->
+                   BinC = unicode:characters_to_binary(C, utf8),
+                   alpaca_ast:symbol(L, <<"("/utf8, BinC/binary, ")"/utf8>>);
       {int_math, L, '%'} -> {bif, '%', L, erlang, 'rem'};
       {minus, L} -> {bif, '-', L, erlang, '-'};
       {plus, L} -> {bif, '+', L, erlang, '+'};
@@ -744,7 +760,8 @@ make_infix(Op, A, B) ->
                   expr=Name,
                   args=[A, B]}.
 
-make_define([{symbol, L, _} = Name|A], Expr, Level) ->
+make_define([{'Symbol', _}=Name|A], Expr, Level) ->
+    L = line(Name),
     case validate_args(L, A) of
         {ok, []} ->
             %% If this is a zero-arg function, at the toplevel, it's a value
@@ -833,26 +850,25 @@ all_literals([M|Rest]) ->
         false -> false
     end.
 
-%% Convert a nullary def into a variable binding:
-make_binding(#alpaca_fun_def{name=N, versions=[#alpaca_fun_version{args=[], body=B}]}, Expr) ->
-    #alpaca_binding{name=N, bound_expr=B, body=Expr};
-%    #var_binding{name=N, to_bind=B, expr=Expr};
 make_binding(Def, Expr) ->
     Def#alpaca_binding{body=Expr}.
 
 term_line(Term) ->
     alpaca_ast_gen:term_line(Term).
 
+bin_to_atom(B) when is_binary(B) ->
+    binary_to_atom(B, utf8).
+
 add_qualifier(#alpaca_bits{}=B, {size, {int, _, I}}) ->
     B#alpaca_bits{size=I, default_sizes=false};
 add_qualifier(#alpaca_bits{}=B, {unit, {int, _, I}}) ->
     B#alpaca_bits{unit=I, default_sizes=false};
 add_qualifier(#alpaca_bits{}=B, {bin_endian, _, E}) ->
-    B#alpaca_bits{endian=list_to_atom(E)};
+    B#alpaca_bits{endian=bin_to_atom(E)};
 add_qualifier(#alpaca_bits{}=B, {bin_type, Enc}) ->
-    B#alpaca_bits{type=list_to_atom(Enc)};
+    B#alpaca_bits{type=bin_to_atom(Enc)};
 add_qualifier(#alpaca_bits{}=B, {bin_sign, _, S}) ->
-    B#alpaca_bits{sign=list_to_atom(S)}.
+    B#alpaca_bits{sign=bin_to_atom(S)}.
 
 make_vars_for_concrete_types(Vars, Line) ->
     F = fun({type_var, _, _}=V, {Vs, VarNum}) ->
@@ -866,4 +882,25 @@ make_vars_for_concrete_types(Vars, Line) ->
 
 type_arity_error(L, Typ, Params) ->
     return_error(L, {wrong_type_arity, Typ, length(Params)}).
+
+symbol_name({symbol, S}) ->
+    alpaca_ast:symbol_name(S);
+symbol_name({'Symbol', _}=S) ->
+    alpaca_ast:symbol_name(S).
+
+symbol_line_name({symbol, S}) ->
+    {alpaca_ast:line(S), alpaca_ast:symbol_name(S)}.
+
+line({symbol, S}) ->
+    alpaca_ast:line(S);
+line(X) ->
+    alpaca_ast:line(X).
+
+%% Yecc requires tuples to start with a token name it can recognize so we can't
+%% actually product and use Alpaca AST nodes straight from Leex.
+unwrap({symbol, S}) ->
+    S;
+unwrap(X) ->
+    X.
+
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -92,7 +92,9 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 >> : {token, {bin_close, TokenLine}}.
 
 %% Symbol
-{SYM}  : {token, {symbol, TokenLine, TokenChars}}.
+{SYM}  :
+  Chars = unicode:characters_to_binary(TokenChars, utf8),
+  {token, {symbol, alpaca_ast:symbol(TokenLine, Chars)}}.
 
 %% Atom
 {ATOM} : {token, {atom, TokenLine, tl(TokenChars)}}.

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -1600,7 +1600,7 @@ typ_of(Env, _Lvl, #alpaca_far_ref{module=Mod, name=N, line=_L, arity=A}) ->
     {ok, #alpaca_module{functions=Funs}} = type_module(Module, Env2),
 
     [Typ] = [Typ || #alpaca_binding{
-                       name={symbol, _, X},
+                       name={'Symbol', #{name := X}},
                        type=Typ,
                        bound_expr=#alpaca_fun{arity=Arity}} <- Funs,
                     N =:= X,

--- a/src/ast.alp
+++ b/src/ast.alp
@@ -1,18 +1,55 @@
 module ast
 
-export_type ast
+export_type binding, module_ast, expr, symbol, opt
 
+export line
+
+export mod
 export int, int_val
 export float, float_val
 export string
+export bind, bind_body, bind_expr
+export symbol, symbol_name, symbol_rename
 
-type ast = Int {line: int, val: int}
-         | Float {line: int, val: float}
-         | String {line: int, val: string}
+type opt 'a = Some 'a | None
 
-let line Int {line=l} = l
-let line Float {line=l} = l
+type typ = TInt
+         | TFloat
+         | TString
+         | Arrow (list typ, typ)
+
+type binding = Binding {  line: int
+                        , name: symbol
+                        , typ: opt typ
+                        , bound: expr
+                        , body: opt expr
+                       }
+
+{- These are the top-level AST nodes that modules are built from.
+ -}
+type module_ast = Module {line: int, name: atom}
+                | binding
+
+let mod line name = Module {line=line, name=name}
+
+type symbol = Symbol {line: int, name: string, original: opt string}
+
+type int_exp = Int {line: int, val: int}
+type float_exp = Float {line: int, val: float}
+
+{- Expressions are only permitted inside of top-level bindings.
+ -}
+type expr = int_exp
+          | float_exp
+          | String {line: int, val: string}
+          | symbol
+          | binding
+
 let line String {line=l} = l
+let line Float {line=l} = l
+let line Int {line=l} = l
+let line Symbol {line=l} = l
+let line Binding {line=l} = l
 
 let int line val = Int {line=line, val=val}
 
@@ -23,3 +60,31 @@ let float line val = Float {line=line, val=val}
 let float_val Float {line=_, val=v} = v
 
 let string line val = String {line=line, val=val}
+
+let bind name line bound =
+  Binding {  line=line
+           , name=name
+           , bound=bound
+           , body=None
+           , typ=None
+          }
+
+let bind name line bound body =
+  Binding {  line=line
+           , name=name
+           , bound=bound
+           , body=Some body
+           , typ=None
+          }
+
+let bind_body Binding b_rec body = Binding {body=Some body | b_rec}
+
+let bind_expr Binding b_rec expr = Binding {bound=expr | b_rec}
+
+let symbol line name = Symbol {line=line, name=name, original=None}
+
+let symbol_name Symbol {name=n} = n
+
+let symbol_rename Symbol {line=l, name=n} new_name =
+  let orig = Some n in
+  Symbol {line=l, name=new_name, original=orig}

--- a/src/ast.alp
+++ b/src/ast.alp
@@ -16,7 +16,7 @@ type opt 'a = Some 'a | None
 type typ = TInt
          | TFloat
          | TString
-         | Arrow (list typ, typ)
+         | TArrow (list typ, typ)
 
 type binding = Binding {  line: int
                         , name: symbol
@@ -77,14 +77,14 @@ let bind name line bound body =
            , typ=None
           }
 
-let bind_body Binding b_rec body = Binding {body=Some body | b_rec}
+let bind_body (Binding b_rec) body = Binding {body=Some body | b_rec}
 
-let bind_expr Binding b_rec expr = Binding {bound=expr | b_rec}
+let bind_expr (Binding b_rec) expr = Binding {bound=expr | b_rec}
 
 let symbol line name = Symbol {line=line, name=name, original=None}
 
 let symbol_name Symbol {name=n} = n
 
-let symbol_rename Symbol {line=l, name=n} new_name =
+let symbol_rename (Symbol {line=l, name=n}) new_name =
   let orig = Some n in
   Symbol {line=l, name=new_name, original=orig}


### PR DESCRIPTION
This changes every internal use of the `symbol` type to that of the Alpaca-native `Symbol` AST node (see `src/ast.alp`).