### PR TITLE
Allows forward references to top-level bindings

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -479,4 +479,11 @@ failing_test_test() ->
     ?assertMatch(error, M:test()),
     code:delete(M).
 
+forward_symbol_reference_test() ->
+    Files = ["test_files/forward_symbol_reference.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(15, M:hof_fail({})),
+    ?assertMatch(15, M:val_fail({})),
+    code:delete(M).
+
 -endif.

--- a/test_files/forward_symbol_reference.alp
+++ b/test_files/forward_symbol_reference.alp
@@ -1,0 +1,17 @@
+module forward_symbol_reference
+
+export hof_fail, val_fail
+
+let apply f x = f x
+
+let hof_fail () =
+    apply add10 5
+
+let val_fail () =
+    10 + val
+
+-- As these are both declared AFTER their usage, neither
+-- of the above functions will compile
+
+let add10 x = x + 10
+let val = 5


### PR DESCRIPTION
Fixes #154.  If there are multiple versions of the top-level binding
referred to this picks the first occurrence since a simple symbol
reference can't tell us which arity we should be looking for (vs
function application where we can make reasonable decisions).