### PR TITLE
Rewrite/bind lambdas in tests

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -486,4 +486,10 @@ forward_symbol_reference_test() ->
     ?assertMatch(15, M:val_fail({})),
     code:delete(M).
 
+lambda_in_test_test() ->
+    Files = ["test_files/lambda_in_test.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(2, M:lambda_test()),
+    code:delete(M).
+
 -endif.

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -394,9 +394,9 @@
 %%% ### Module Building Blocks
 
 -record(alpaca_test, {type=undefined :: typ(),
-                    line=0 :: integer(),
-                    name={string, 0, ""} :: alpaca_string(),
-                    expression={unit, 0} :: alpaca_expression()}).
+                      line=0 :: integer(),
+                      name={string, 0, ""} :: alpaca_string(),
+                      expression={unit, 0} :: alpaca_expression()}).
 -type alpaca_test() :: #alpaca_test{}.
 
 %%% Expressions that result in values:

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -251,9 +251,7 @@ gen_fun_version(Env, #alpaca_fun_version{args=Args, guards=Gs, body=Body}) ->
     end.
 
 gen_tests(Env, Tests) ->
-    io:format("~p~n", [Tests]),
     Rewritten = lists:reverse([rewrite_lambdas(T) || T <- Tests]),
-    io:format("~p~n", [Rewritten]),
     gen_tests(Env, Rewritten, []).
 
 gen_tests(#env{prefixed_module=PM}, [], Memo) ->

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -99,7 +99,18 @@ rewrite_lambdas(#alpaca_binding{bound_expr=BE, body=undefined}=TopBinding) ->
                   B
           end,
 
-    TopBinding#alpaca_binding{bound_expr=BE2}.
+    TopBinding#alpaca_binding{bound_expr=BE2};
+rewrite_lambdas(#alpaca_test{expression=Exp, line=L}=Test) ->
+    {_, Exp2, Bindings} = rewrite_lambdas(Exp, 0, []),
+    F = fun({Name, Exp}, Chain) ->
+                #alpaca_binding{name=Name,
+                                line=L,
+                                bound_expr=Exp,
+                                body=Chain}
+        end,
+
+    Rebound = lists:foldl(F, Exp2, lists:flatten(Bindings)),
+    Test#alpaca_test{expression=Rebound}.
 
 %% Rewriting a sequence of function versions or a sequence of function arguments
 %% is basically the same so let's just use one function for both.
@@ -240,7 +251,10 @@ gen_fun_version(Env, #alpaca_fun_version{args=Args, guards=Gs, body=Body}) ->
     end.
 
 gen_tests(Env, Tests) ->
-    gen_tests(Env, Tests, []).
+    io:format("~p~n", [Tests]),
+    Rewritten = lists:reverse([rewrite_lambdas(T) || T <- Tests]),
+    io:format("~p~n", [Rewritten]),
+    gen_tests(Env, Rewritten, []).
 
 gen_tests(#env{prefixed_module=PM}, [], Memo) ->
     FName = cerl:c_fname(test, 0),

--- a/test_files/lambda_in_test.alp
+++ b/test_files/lambda_in_test.alp
@@ -1,0 +1,6 @@
+module lambda_in_test
+
+let apply f a = f a
+
+test "lambda" =
+  apply (fn x -> x + 1) 1


### PR DESCRIPTION
Fixes #143, allows us to use lambdas in the body of tests, specifically
when passed as arguments to other functions under test.