### PR TITLE
Apply expression rebinding to tests

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -492,4 +492,11 @@ lambda_in_test_test() ->
     ?assertMatch(2, M:lambda_test()),
     code:delete(M).
 
+tests_in_imports_test() ->
+    Files = ["test_files/asserts.alp", "test_files/tests_and_imports.alp"],
+    [M1, M2] = compile_and_load(Files, [test]),
+    ?assertMatch(true, M2:example_test()),
+    code:delete(M1),
+    code:delete(M2).
+
 -endif.

--- a/test_files/tests_and_imports.alp
+++ b/test_files/tests_and_imports.alp
@@ -1,0 +1,6 @@
+module tests_and_imports
+
+import asserts.assert_equal
+
+test "example" =
+  assert_equal 2 2


### PR DESCRIPTION
Previously we weren't applying the rebinding/renaming pass to tests that
we were to functions so things like import renaming and pattern binding
weren't happening during the AST generation stage.

Fixes #144 