### PR TITLE
Escape \ style sequences in strings

### DIFF
--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -114,6 +114,20 @@ symbol_test_() ->
 atom_test_() ->
     [?_assertEqual({ok, [{atom, 1, "myAtom"}], 1}, scan(":myAtom"))].
 
+string_escape_test_() ->
+    [?_assertEqual({ok, [{string, 1, "one\ntwo\n\tthree"}], 1}, 
+                   scan("\"one\\ntwo\\n\\tthree\"")),
+     ?_assertEqual({ok, [{string, 1, "this is a \"quoted\" string"}], 1}, 
+                   scan("\"this is a \\\"quoted\\\" string\"")),
+     ?_assertEqual({ok, [{string, 1, "C:\\MYCMD.BAT"}], 1}, 
+                   scan("\"C:\\\\MYCMD.BAT\"")),
+     ?_assertMatch({error,{1,alpaca_scan,
+                         {user,{{error,"Bad control sequence"},
+                                1, _}}},
+                        1},
+                   scan("\"\\! \\} \\<\""))].
+            
+
 let_test() ->
     Code = "let symbol = 5",
     ExpectedTokens = [{'let', 1},


### PR DESCRIPTION
I thought it most appropriate to perform this in the scanner. This only handles the simpler cases as described here: http://erlang.org/doc/reference_manual/data_types.html#id76758, ignoring hex, octal and Control A to control Z, but it would be possible to add these if they were desirable and didn't interfere with UTF8 rules. This also doesn't escape single quotes as I'm not sure there's any necessity.