### PR TITLE
Quoted atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ course you're using the aforementioned rebar3 plugin/
 Most of the basic Erlang data types are supported:
 
 - booleans, `true` or `false`
-- atoms, `:atom`
+- atoms, `:atom`, `:"Quoted Atom!"`
 - floats, `1.0`
 - integers, `1`
 - strings, `"A string"`.  These are encoded as UTF-8 binaries.

--- a/Tour.md
+++ b/Tour.md
@@ -140,7 +140,7 @@ Alpaca has integers and floats which can't mix with each other at all.  They hav
 
 ### Atoms<a id="sec-3-1-3" name="sec-3-1-3"></a>
 
-Atoms in Alpaca are just text prefixed with `:`, e.g. `:this_is_an_atom` and `:soIsThis1`.
+Atoms in Alpaca are just text prefixed with `:`, e.g. `:this_is_an_atom` and `:soIsThis1`. Quotes may be used if spaces or symbols are required, e.g. `:"still an atom!"`.
 
 ### Strings<a id="sec-3-1-4" name="sec-3-1-4"></a>
 

--- a/Tour.org
+++ b/Tour.org
@@ -77,7 +77,7 @@ Alpaca has integers and floats which can't mix with each other at all.  They hav
 #+END_SRC
 
 *** Atoms
-Atoms in Alpaca are just text prefixed with ~:~, e.g. ~:this_is_an_atom~ and ~:soIsThis1~.
+Atoms in Alpaca are just text prefixed with ~:~, e.g. ~:this_is_an_atom~ and ~:soIsThis1~. Quotes may be used if spaces or symbols are required, e.g. ~:"still an atom!"~.
 *** Strings
 Strings in Alpaca are all assumed UTF-8 and will be encoded as such:
 #+BEGIN_SRC

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -98,6 +98,9 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Atom
 {ATOM} : {token, {atom, TokenLine, tl(TokenChars)}}.
+{ATOM}"(\\"*|\\.|[^"\\])*" : 
+  S = string:substr(TokenChars, 3, TokenLen - 3),
+  {token, {atom, TokenLine, S}}.
 
 %% String
 "(\\"*|\\.|[^"\\])*" :

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -114,6 +114,10 @@ symbol_test_() ->
 atom_test_() ->
     [?_assertEqual({ok, [{atom, 1, "myAtom"}], 1}, scan(":myAtom"))].
 
+quoted_atom_test_() ->
+    [?_assertEqual({ok, [{atom, 1, "Quoted.Atom-Value"}], 1},
+                   scan(":\"Quoted.Atom-Value\""))].
+
 string_escape_test_() ->
     [?_assertEqual({ok, [{string, 1, "one\ntwo\n\tthree"}], 1}, 
                    scan("\"one\\ntwo\\n\\tthree\"")),


### PR DESCRIPTION
This PR adds simple quoted atoms in the Elixir style, e.g.

```elixir
:"This.Is.A.Quoted!Atom?"
```

Amongst other things this is useful for calling Elixir modules as requested in #159 