### PR TITLE
Module deps

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -23,6 +23,7 @@
         , compiler_info/0
         , hash_source/1
         , retrieve_hash/1
+        , list_dependencies/1
         ]).
 
 %% Can be safely ignored, it is meant to be called by external OTP-apps and part
@@ -34,6 +35,7 @@
              , compiler_info/0
              , hash_source/1
              , retrieve_hash/1
+             , list_dependencies/1
              ]).
 
 -include("alpaca_ast.hrl").
@@ -109,6 +111,9 @@ hash_source(Src) ->
 retrieve_hash(Filename) ->
     {ok,{_,[{attributes,A}]}} = beam_lib:chunks(Filename,[attributes]),
     proplists:get_value(alpaca_hash, A).
+
+list_dependencies(Src) ->
+    alpaca_ast_gen:list_dependencies(Src).
 
 maybe_print_exhaustivess_warnings(Warnings, Opts) ->
   case proplists:get_value(warn_exhaustiveness, Opts, true) of

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -8,7 +8,7 @@
 %% make_modules/1 is useful externally for a simple way of compiling
 %% multiple source files together; list_dependencies allows external tools
 %% to extract module dependencies from source code without compiling.
--ignore_xref([parse/1, make_modules/1, list_dependencies/1]).
+-ignore_xref([parse/1, make_modules/1]).
 
 -include("alpaca_ast.hrl").
 

--- a/src/alpaca_error_format.erl
+++ b/src/alpaca_error_format.erl
@@ -28,8 +28,8 @@ fmt({error, {parse_error, F, L, E}}, Locale) ->
     Line = integer_to_binary(L),
     Msg = fmt_parse_error(E, Locale),
     <<File/binary, ":"/utf8, Line/binary, ": "/utf8, Msg/binary, "\n"/utf8>>;
-fmt({error, _}=Err, Locale) ->
-    Msg = fmt_unknown_error(Err, Locale),
+fmt({error, Err}, Locale) ->
+    Msg = fmt_parse_error(Err, Locale),
     <<Msg/binary, "\n"/utf8>>.
 
 fmt_parse_error({duplicate_definition, Id}, Locale) ->
@@ -54,8 +54,10 @@ fmt_parse_error({module_rename, Old, New}, Locale) ->
       [{old, atom_to_binary(Old, utf8)}, {new, atom_to_binary(New, utf8)}]);
 fmt_parse_error(no_module, Locale) ->
     t(__(<<"no_module">>), Locale);
+fmt_parse_error({no_module, Mod}, Locale) when is_atom(Mod) ->
+    t(__(<<"no_module %(mod)">>), Locale, [{mod, atom_to_binary(Mod, utf8)}]);
 fmt_parse_error({no_module, Mod}, Locale) ->
-    t(__(<<"no_module %(mod)">>), Locale, [{module, Mod}]);
+    t(__(<<"no_module %(mod)">>), Locale, [{mod, Mod}]);
 fmt_parse_error({syntax_error, ""}, Locale) ->
     t(__(<<"incomplete_expression">>), Locale);
 fmt_parse_error({syntax_error, Token}, Locale) ->
@@ -130,7 +132,7 @@ fmt_unknown_parse_error_test() ->
 fmt_unknown_error_test() ->
   Error = {error, unknown},
   Msg = fmt(Error, "en_US"),
-  Expected = <<"{error,unknown}\n"
+  Expected = <<"unknown\n"
                "Sorry, we do not have a proper message for this error yet.\n"
                "Please consider filing an issue at "
                "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,


### PR DESCRIPTION
Adds a function for listing out dependencies from Alpaca source without having to compile.

This is useful for calculating the dependency graph of a given module, meaning that an external tool such as the rebar plugin may feed modules into Alpaca in the optimal order, and may force a module to be recompiled if one of its dependency changes.

I put this into the `alpaca_ast_gen` module as it was able to reuse some of the mechanisms there, but perhaps the list_dependencies fun should also be exposed from the alpaca main module for the 'public interface' aspect.