### PR TITLE
Default imports

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -83,7 +83,9 @@ compile_phase_1(Sources, Opts) ->
                             filename:extension(FN) == ".beam"
                         end, Sources),
 
-    case alpaca_ast_gen:make_modules(AlpacaSrcs, BeamFiles) of
+    DefaultImports = proplists:get_value(default_imports, Opts, {[], []}),
+
+    case alpaca_ast_gen:make_modules(AlpacaSrcs, BeamFiles, DefaultImports) of
         {error, _}=Err -> Err;
         {ok, Mods} ->
             compile_phase_2(Mods, Opts)
@@ -614,6 +616,24 @@ hash_annotation_test() ->
     {module, N} = code:load_binary(N, FN, Bin),
     ?assertEqual(Hash, proplists:get_value(alpaca_hash, N:module_info(attributes))),
     ?assertEqual(Hash, hash_source(R)),
+    code:delete(N).
+
+default_imports_test() ->
+    Files = ["test_files/default.alp", "test_files/use_default.alp"],
+
+    DefaultImports = {
+        [{<<"identity">>, default}, {<<"always">>, default}], []},
+
+    {ok, [Default, Compiled]} = alpaca:compile(
+        {files, Files},
+        [{default_imports, DefaultImports}]),
+
+    {compiled_module, N, FN, Bin} = Compiled,
+    {compiled_module, N2, FN2, Bin2} = Default,
+    {module, N} = code:load_binary(N, FN, Bin),
+    code:load_binary(N2, FN2, Bin2),
+
+    ?assertEqual(42, N:main({})),
     code:delete(N).
 
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -622,7 +622,8 @@ default_imports_test() ->
     Files = ["test_files/default.alp", "test_files/use_default.alp"],
 
     DefaultImports = {
-        [{<<"identity">>, default}, {<<"always">>, default}], []},
+        [{default, <<"identity">>}, {default, <<"always">>, 2}],
+        [{default, <<"box">>}]},
 
     {ok, [Default, Compiled]} = alpaca:compile(
         {files, Files},
@@ -633,7 +634,7 @@ default_imports_test() ->
     {module, N} = code:load_binary(N, FN, Bin),
     code:load_binary(N2, FN2, Bin2),
 
-    ?assertEqual(42, N:main({})),
+    ?assertEqual({'Box', 42}, N:main({})),
     code:delete(N).
 
 -endif.

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -8,7 +8,7 @@
 %% make_modules/1 is useful externally for a simple way of compiling
 %% multiple source files together; list_dependencies allows external tools
 %% to extract module dependencies from source code without compiling.
--ignore_xref([parse/1, make_modules/1]).
+-ignore_xref([parse/1, make_modules/1, make_modules/2]).
 
 -include("alpaca_ast.hrl").
 
@@ -93,10 +93,22 @@ make_modules(Code, PrecompiledMods, DefaultImports) ->
 
       {DefaultFuns, DefaultTypes} = DefaultImports,
 
+      DefaultFunsA = lists:map(
+          fun ({Mod, F}) -> {F, Mod};
+              ({Mod, F, Arity}) -> {F, {Mod, Arity}}
+          end,
+          DefaultFuns),
+
+      DefaultTypesA = lists:map(
+          fun({Mod, T}) -> #alpaca_type_import{module=Mod, type=T} end,
+          DefaultTypes),
+
       %% Inject funs
       ModulesWithDefaults = lists:map(
-          fun(#alpaca_module{function_imports=Imports}=M) ->
-              M#alpaca_module{function_imports=Imports ++ DefaultFuns}
+          fun(#alpaca_module{function_imports=Imports, type_imports=Types}=M) ->
+              M#alpaca_module{
+                  function_imports=Imports ++ DefaultFunsA,
+                  type_imports=Types ++ DefaultTypesA}
           end,
           Modules),
 

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1,7 +1,7 @@
 %%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %%% ex: ft=erlang ts=4 sw=4 et
 -module(alpaca_ast_gen).
--export([parse/1, make_modules/1, make_modules/2, term_line/1, list_dependencies/1]).
+-export([parse/1, make_modules/1, make_modules/2, make_modules/3, term_line/1, list_dependencies/1]).
 
 %% Parse is used by other modules (particularly alpaca_typer) to make ASTs
 %% from code that does not necessarily include a module;
@@ -75,21 +75,46 @@ make_modules(Code) ->
         throw:{parse_error, _, _, _}=Err -> {error, Err}
     end.
 
--spec make_modules(Sources, PrecompiledMods) -> {ok, [alpaca_module()]} | {error, Error} when
-    Sources :: list(Source),
-    Source :: {filename(), Code},
-    PrecompiledMods :: list(PrecompiledMod),
-    PrecompiledMod :: {filename(), alpaca_module()},
-    Code :: string() | binary(),
-    Error :: parse_error().
-make_modules(Code, PrecompiledMods) ->
+-spec make_modules(Sources, PrecompiledMods, DefaultImports) ->
+    {ok, [alpaca_module()]} | {error, Error} when
+        Sources :: list(Source),
+        Source :: {filename(), Code},
+        PrecompiledMods :: list(PrecompiledMod),
+        PrecompiledMod :: {filename(), alpaca_module()},
+        DefaultTypes :: list({string(), {atom(), integer()}|string()}),
+        DefaultFuns :: list(alpaca_type_import()),
+        DefaultImports :: {DefaultFuns, DefaultTypes},
+        Code :: string() | binary(),
+        Error :: parse_error().
+make_modules(Code, PrecompiledMods, DefaultImports) ->
     try
       Modules = [parse_module(SourceCode) || SourceCode <- Code],
       PCMods = [M || {_FN, M} <- PrecompiledMods],
-      {ok, rename_and_resolve(PCMods ++ Modules)}
+
+      {DefaultFuns, DefaultTypes} = DefaultImports,
+
+      %% Inject funs
+      ModulesWithDefaults = lists:map(
+          fun(#alpaca_module{function_imports=Imports}=M) ->
+              M#alpaca_module{function_imports=Imports ++ DefaultFuns}
+          end,
+          Modules),
+
+      {ok, rename_and_resolve(PCMods ++ ModulesWithDefaults)}
     catch
         throw:{parse_error, _, _, _}=Err -> {error, Err}
     end.
+
+-spec make_modules(Sources, PrecompiledMods) ->
+    {ok, [alpaca_module()]} | {error, Error} when
+        Sources :: list(Source),
+        Source :: {filename(), Code},
+        PrecompiledMods :: list(PrecompiledMod),
+        PrecompiledMod :: {filename(), alpaca_module()},
+        Code :: string() | binary(),
+        Error :: parse_error().
+make_modules(Code, PrecompiledMods) ->
+    make_modules(Code, PrecompiledMods, {[], []}).
 
 parse_error(#alpaca_module{filename=FileName}, Line, Error) ->
     throw({parse_error, FileName, Line, Error}).

--- a/test_files/default.alp
+++ b/test_files/default.alp
@@ -1,0 +1,7 @@
+module default
+
+export identity, always
+
+let identity x = x
+
+let always x _ = x

--- a/test_files/default.alp
+++ b/test_files/default.alp
@@ -1,6 +1,9 @@
 module default
 
 export identity, always
+export_type box
+
+type box 'a = Box 'a
 
 let identity x = x
 

--- a/test_files/use_default.alp
+++ b/test_files/use_default.alp
@@ -1,0 +1,8 @@
+module use_default
+
+export main/1
+
+-- `identity` and `always` are defined in the `default` module
+
+let main () = let same = identity 42 in
+              always same 1

--- a/test_files/use_default.alp
+++ b/test_files/use_default.alp
@@ -2,7 +2,7 @@ module use_default
 
 export main/1
 
--- `identity` and `always` are defined in the `default` module
+-- `identity`, `always` and `box` are defined in the `default` module
 
-let main () = let same = identity 42 in
-              always same 1
+let main () = let same = identity (Box 42) in
+              always same (Box 1)


### PR DESCRIPTION
Submitting this PR so we can discuss.

This adds an option to existing opts list in alpaca:compile of `default_imports` which allows the user to specify functions and types that will be brought into scope in every module without explicit imports.

The main aim of this is so that we can have 'standard library' functions and types that are available to all modules. I imagine that alpaca_lib could define its defaults in a file which the rebar plugin could read; if alpaca_lib is available to the rebar plugin, it would use this list of defaults. This would mean that the default functions could actually be changed by alpaca_lib itself as more are added. Some candidates would be operators such as (<|), (|>), and types such as `maybe/some` and `result`, and general utility functions like `always`, `identity`.

With this approach (explicitly listing all imports and types) we don't need to bundle all defaults into a single module, but they can be specified quite naturally across multiple modules.

I originally used Alpaca's own AST representation of the imports, but I decided to make them a bit more consistent, so function imports are defined as `{Mod, Fun}` or `{Mod, Fun, Arity}` and types are specified as `{Mod, Type}`.