### PR TITLE
Allow (<) leading infixes to have right assoc

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -23,7 +23,7 @@
         , compiler_info/0
         , hash_source/1
         , retrieve_hash/1
-        , list_dependencies/1
+        , list_dependencies/1 
         ]).
 
 %% Can be safely ignored, it is meant to be called by external OTP-apps and part

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -23,7 +23,7 @@
         , compiler_info/0
         , hash_source/1
         , retrieve_hash/1
-        , list_dependencies/1 
+        , list_dependencies/1
         ]).
 
 %% Can be safely ignored, it is meant to be called by external OTP-apps and part

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -806,6 +806,20 @@ infix_fun_test() ->
     ?assertEqual(20, Name:adder(10)),
     true = code:delete(Name).
 
+infix_left_fun_test() ->
+    Name = alpaca_infix_left_fun,
+    FN = atom_to_list(Name) ++ ".beam",
+    Code =
+        "module infix_left_fun\n\n"
+        "export main/1 \n\n"
+        "let (<|) f x = f x\n\n"
+        "let add x = x + 10\n\n"
+        "let main () = add <| add <| add <| add 12",
+    {ok, _, Bin} = parse_and_gen(Code),
+    {module, Name} = code:load_binary(Name, FN, Bin),
+    ?assertEqual(52, Name:main({})),
+    true = code:delete(Name).
+
 fun_and_var_binding_test() ->
     Name = alpaca_fun_and_var_binding,
     FN = atom_to_list(Name) ++ ".beam",

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -21,7 +21,10 @@ L   = [a-z]
 U   = [A-Z]
 SYM = {L}[a-zA-Z0-9_]*
 O  = [\.\*<>\|\$~\^=\?\+@%/]
-OP = {O}{O}*
+OL = [\.\*>\|\$~\^=\?\+@%/]
+OR = [<]
+OPR = {OR}{O}*
+OPL = {OL}{O}*
 ATOM = :[a-zA-Z0-9_\*]*
 TYPE = {U}[a-zA-Z0-9_]*
 WS  = [\000-\s]
@@ -137,8 +140,8 @@ _        : {token, {'_', TokenLine}}.
 
 %% Non-predefined infixes
 
-{OP} : {token, {infixable, TokenLine, TokenChars}}.
-
+{OPL} : {token, {infixl, TokenLine, TokenChars}}.
+{OPR} : {token, {infixr, TokenLine, TokenChars}}.
 
 %% Whitespace ignore
 {WS} : skip_token.


### PR DESCRIPTION
This PR causes infixes that start with (<) to be right associative.

Allowing infixes to be left or right allows defining an operator such as Elm's pipe backward/apply `(<|)` , similar to Haskell's `($)`, which is really useful for eliminating parentheses, e.g. 

`add <| add <| add 10` instead of `add (add (add 10))`

With Yecc the associativity has to be predefined, i.e. it wouldn't be possible to specify the desired associativity in Alpaca source code. OCaml's approach is that the leading char in the infix specifies its associativity. In this PR everything is currently assumed to be left assoc, unless it begins with a leading `<`. The associativity is defined here: https://github.com/ocaml/ocaml/blob/trunk/parsing/parser.mly#L563 and the operator groups here: https://github.com/ocaml/ocaml/blob/trunk/parsing/lexer.mll#L500

For context, I'm thinking of operators that might be defined by standard in alpaca_lib.