### PR TITLE
Problem: var lookup fails in exhaustiveness checks

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -637,4 +637,15 @@ default_imports_test() ->
     ?assertEqual({'Box', 42}, N:main({})),
     code:delete(N).
 
+built_in_adt_exhaustiveness_test() ->
+    Files = ["test_files/exhaustiveness_cases.alp"],
+    [M1] = compile_and_load(Files, [test]),
+    ?assertMatch(
+       #{'__struct__' := record,
+         arity := 'None',
+         line := 1,
+         name := <<"make_export">>},
+       M1:make_export(1, <<"make_export">>)),
+    code:delete(M1).
+
 -endif.

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -888,7 +888,7 @@ make_vars_for_concrete_types(Vars, Line) ->
     F = fun({type_var, _, _}=V, {Vs, VarNum}) ->
                 {[V|Vs], VarNum};
            (Expr, {Vs, VarNum}) ->
-                VN = ":SynthTypeVar_" ++ integer_to_list(VarNum),
+                VN = {synthetic, ":SynthTypeVar_" ++ integer_to_list(VarNum)},
                 {[{{type_var, Line, VN}, Expr}|Vs], VarNum + 1}
         end,
     {Vs, _} = lists:foldl(F, {[], 0}, Vars),

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -2287,7 +2287,7 @@ type_map(Env, Lvl, #alpaca_map{pairs=Pairs}) ->
     Env2 = update_counter(NV, Env),
     case unify_map_pairs(Env2, Lvl, Pairs, MapType) of
         {error, _}=Err -> Err;
-        {Type, #env{next_var=NV}} -> {Type, NV}
+        {Type, #env{next_var=NV2}} -> {Type, NV2}
     end.
 unify_map_pairs(Env, _, [], T) ->
     {new_cell(T), Env};

--- a/test_files/exhaustiveness_cases.alp
+++ b/test_files/exhaustiveness_cases.alp
@@ -1,0 +1,46 @@
+module record_types
+
+export make_export, make_exports
+export make_t
+
+type opt 'a = Some 'a | None
+
+type module_ast = Module {line: int, name: atom}
+                | Exports list {line: int, name: string, arity: opt int}
+
+let make_export l n = {line=l, name=n, arity=None}
+let make_export l n a = {line=l, name=n, arity=Some a}
+
+let make_exports es = Exports es
+
+type t = T map string (opt int)
+
+let make_t x = T #{"x" => x}
+
+type tt 't = TT map string (opt 't)
+
+let make_tt x = TT #{"x" => x}
+
+type u = U opt int
+
+let make_u x = U Some x
+
+let int_u U Some u = u
+ 
+type v = V list (opt int)
+
+let make_v vs = V vs
+
+type int_opt = opt int
+
+type x = X int_opt
+
+let make_x x = X Some x
+
+type z = Z (int, opt int)
+
+let make_z z = Z (z, Some z)
+
+type r = R list {x: int, y: opt int}
+
+let make_r r = R r


### PR DESCRIPTION
ADTs that referred to other ADTs (e.g. a type that uses the option type)
that:

- use different variable names
- use concrete types, leading to synthetic variable names

were causing crashes in the exhaustiveness checker.  Caught this when
using options inside of records, the same issue occurred with lists and
maps as well.  Now the exhaustiveness checker substitutes the original
variable names before checking each type variable for coverage.

Fixes #170 