### PR TITLE
Allow currying on local 'let' bound funs

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -446,6 +446,8 @@ function_in_adt_test() ->
 curry_test() ->
     [M] = compile_and_load(["test_files/curry.alp"], []),
     ?assertEqual({16,26,[2]}, M:foo({})),
+    LocalFun = M:local({}),
+    ?assertEqual(100, LocalFun(90)),
     code:delete(M).
 
 curry_import_export_test() ->

--- a/test_files/curry.alp
+++ b/test_files/curry.alp
@@ -1,6 +1,7 @@
 module curry
 
 export foo/1
+export local
 export filter
 export (|>)
 
@@ -35,6 +36,10 @@ let eq a b =
 let filtered_list () =
   [1, 2, 3]
   |> filter (eq 2)
+
+let local () =
+  let f x y = x + y in
+  f 10
 
 let foo () =
   let many_args_curry = many_args 1 in


### PR DESCRIPTION
I realised I never got round to this - it turned out to be much easier than I thought (logically, if the typer finds an arrow that it can unify, and the arrow didn't come from the top level or another module, it must be from a let binding).

I guess the only concern is whether this might interfere with defining multiple arity funs in local bindings, but AFAIK it is currently impossible to define multiple let bindings with differing arities and the same name anyway; if it became possible in future we could apply the same rules for detecting ambiguous curries.

If we're happy about the currying rules overall, this also closes issue https://github.com/alpaca-lang/alpaca/issues/74