### PR TITLE
[WIP] Nicer errros

### DIFF
--- a/priv/lang/alpaca.de_DE.po
+++ b/priv/lang/alpaca.de_DE.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-msgid "builtin_type_arity_error %(num_expected) %(num_supplied)"
+msgid "builtin_type_arity_error %(type) %(num_expected) %(num_supplied)"
 msgstr ""
 "Falsche Anzahl an Parametern für eingebauten Typ\"%(type)\".\n"
 "Erwartet %(num_expected), erhalten %(num_supplied)."
@@ -23,7 +23,7 @@ msgstr "Mehrfache Definition von \"%(id)\"."
 msgid "duplicate_type_definition %(id)"
 msgstr "Der Typ \"%(id)\" wurde bereits definiert."
 
-msgid "function_not_exported %(mod) %(name)"
+msgid "function_not_exported %(mod) %(fun)"
 msgstr "Das Modul \"%(mod)\" exportiert die Funktion \"%(fun)\" nicht."
 
 msgid "incomplete_expression"

--- a/priv/lang/alpaca.en_US.po
+++ b/priv/lang/alpaca.en_US.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-msgid "builtin_type_arity_error %(num_expected) %(num_supplied)"
+msgid "builtin_type_arity_error %(type) %(num_expected) %(num_supplied)"
 msgstr ""
 "Wrong number of type parameters provided for builtin type \"%(type)\".\n"
 "Expected %(num_expected), but got %(num_supplied)."
@@ -23,7 +23,7 @@ msgstr "Duplicate definition of \"%(id)\"."
 msgid "duplicate_type_definition %(id)"
 msgstr "Type \"%(id)\" has already been defined."
 
-msgid "function_not_exported %(mod) %(name)"
+msgid "function_not_exported %(mod) %(fun)"
 msgstr "No function \"%(fun)\" exported from module \"%(mod)\"."
 
 msgid "incomplete_expression"

--- a/priv/lang/alpaca.es_MX.po
+++ b/priv/lang/alpaca.es_MX.po
@@ -12,7 +12,7 @@ msgstr ""
 "Last-Translator: Eric Bailey <eric@ericb.me>\n"
 "Language: es_MX\n"
 
-msgid "builtin_type_arity_error %(num_expected) %(num_supplied)"
+msgid "builtin_type_arity_error %(type) %(num_expected) %(num_supplied)"
 msgstr ""
 "Número incorrecto de parámetros de tipo proporcionados\n"
 "para el tipo incorporado \"%(type)\".\n"
@@ -24,7 +24,7 @@ msgstr "Definición duplicada de \"%(id)\"."
 msgid "duplicate_type_definition %(id)"
 msgstr "Tipo \"%(id)\" ya se ha definido."
 
-msgid "function_not_exported %(mod) %(name)"
+msgid "function_not_exported %(mod) %(fun)"
 msgstr "No hay ninguna función \"%(fun)\" que se exporte desde el módulo \"%(mod)\"."
 
 msgid "incomplete_expression"

--- a/priv/lang/alpaca.pot
+++ b/priv/lang/alpaca.pot
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: alpaca\n"
-"POT-Creation-Date: 2017-03-20 06:41+0100\n"
+"POT-Creation-Date: 2017-06-14 16:46+0200\n"
 "Plural-Forms: nplurals=1; plural=1;\n"
 
-msgid "builtin_type_arity_error %(num_expected) %(num_supplied)"
+msgid "builtin_type_arity_error %(type) %(num_expected) %(num_supplied)"
 msgstr ""
 
 msgid "duplicate_definition %(id)"
@@ -14,7 +14,7 @@ msgstr ""
 msgid "duplicate_type_definition %(id)"
 msgstr ""
 
-msgid "function_not_exported %(mod) %(name)"
+msgid "function_not_exported %(mod) %(fun)"
 msgstr ""
 
 msgid "incomplete_expression"

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 {erl_opts, [debug_info, {gettext, alpaca_compiled_po}]}.
 {xrl_opts, [{report, true}, {verbose, true}]}.
 {deps, [ {epo_runtime, {git, "git://github.com/brigadier/epo_runtime.git",
-                        {tag, "0.3"}}}
+                        {tag, "0.3"}}},
+         cf
        ]}.
 {dialyzer, [{warnings, [unknown]}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
 {"1.1.0",
-[{<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
+[{<<"cf">>,{pkg,<<"cf">>,<<"0.3.1">>},0},
  {<<"epo_runtime">>,
   {git,"git://github.com/brigadier/epo_runtime.git",
        {ref,"a3e50e7cebb526f833757e867bbe914c1da7baa3"}},
   0}]}.
 [
 {pkg_hash,[
- {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>}]}
+ {<<"cf">>, <<"5CB902239476E141EA70A740340233782D363A31EEA8AD37049561542E6CD641">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,10 @@
-[{<<"epo_runtime">>,
+{"1.1.0",
+[{<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},0},
+ {<<"epo_runtime">>,
   {git,"git://github.com/brigadier/epo_runtime.git",
        {ref,"a3e50e7cebb526f833757e867bbe914c1da7baa3"}},
-  0}].
+  0}]}.
+[
+{pkg_hash,[
+ {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>}]}
+].

--- a/src/alpaca_error_format.erl
+++ b/src/alpaca_error_format.erl
@@ -179,7 +179,7 @@ read_lines(Device, Line, Target, Fn, Acc) ->
         Txt ->
             L1 = case Line of
                      Target ->
-                         cf("  ~!r~4b~!!: ~ts", [Line, Fn(Txt)]);
+                         cf("  ~!#d01c8b~4b~!!: ~ts", [Line, Fn(Txt)]);
                      _ ->
                          cf("  ~!c~4b~!!: ~ts", [Line, Txt])
                  end,
@@ -187,10 +187,10 @@ read_lines(Device, Line, Target, Fn, Acc) ->
     end.
 
 red(S) ->
-    cf("~!r~ts", [S]).
+    cf("~!#d01c8b~ts", [S]).
 
 green(S) ->
-    cf("~!g~ts", [S]).
+    cf("~!#4dac26~ts", [S]).
 
 bold(S) ->
     cf("~!^~ts", [S]).
@@ -282,13 +282,14 @@ syntax_error_hl_c_test() ->
     ParseError = {syntax_error, "="},
     Error = {error, {parse_error, File, Line, ParseError}},
     Msg = test_fmt_c(Error),
-    Expected = <<"\e[4mtest/\e[0;36m\e[4merror\e[0m\e[4m.alp\e[0m:"
-                 "\e[0;36m11\e[0m\e[0m\n"
-                 "  Syntax error before \"\e[0;31m=\e[0m\".\n\n"
-                 "  \e[0;36m   9\e[0m: let format ast_node = format_ast "
-                 "0 ast_node\n"
+    Expected = <<"\e[4mtest/\e[0;36m\e[4merror\e[0m\e[4m.alp\e[0m"
+                 ":\e[0;36m11\e[0m\e[0m\n"
+                 "  Syntax error before \"\e[38;2;208;28;139m=\e[0m\".\n\n"
+                 "  \e[0;36m   9\e[0m: let format "
+                 "ast_node = format_ast 0 ast_node\n"
                  "\e[0m  \e[0;36m  10\e[0m: \n"
-                 "\e[0m  \e[0;31m  11\e[0m: let max_len = \e[0;31m=\e[0m 80\n"
+                 "\e[0m  \e[38;2;208;28;139m  11\e[0m: let max_len = "
+                 "\e[38;2;208;28;139m=\e[0m 80\n"
                  "\e[0m  \e[0;36m  12\e[0m: \n"
                  "\e[0m  \e[0;36m  13\e[0m: let format_ast depth Symbol "
                  "{name=name} =\n\e[0m\n\e[0m">>,
@@ -300,9 +301,10 @@ en_us_syntax_color_test() ->
     ParseError = {syntax_error, "blah"},
     Error = {error, {parse_error, File, Line, ParseError}},
     Msg = test_fmt_c(Error),
-    Expected = <<"\e[4m/tmp/\e[0;36m\e[4mfile\e[0m\e[4m.alp\e[0m:\e[0;36m10"
-                 "\e[0m\e[0m\n"
-                 "  Syntax error before \"\e[0;31mblah\e[0m\".\n\e[0m">>,
+    Expected = <<"\e[4m/tmp/\e[0;36m\e[4mfile\e[0m\e[4m.alp\e[0m:"
+                 "\e[0;36m10\e[0m\e[0m\n"
+                 "  Syntax error before "
+                 "\"\e[38;2;208;28;139mblah\e[0m\".\n\e[0m">>,
     ?assertEqual(Expected, Msg).
 
 function_not_exported_test() ->
@@ -323,7 +325,7 @@ function_not_exported_c_test() ->
     Msg = test_fmt_c(Error),
     Expected = <<"\e[4m/tmp/\e[0;36m\e[4mmodule\e[0m\e[4m.alp\e[0m:"
                  "\e[0;36m10\e[0m\e[0m\n"
-                 "  No function \"\e[0;31mfun\e[0m\" "
+                 "  No function \"\e[38;2;208;28;139mfun\e[0m\" "
                  "exported from module \"\e[1mmodule\e[0m\".\n\e[0m">>,
     ?assertEqual(Expected, Msg).
 
@@ -347,9 +349,10 @@ buildin_type_arity_c_test() ->
     Msg = test_fmt_c(Error),
     Expected = <<"\e[4m/tmp/\e[0;36m\e[4mmodule\e[0m\e[4m.alp\e[0m:"
                  "\e[0;36m10\e[0m\e[0m\n"
-                 "  Wrong number of type parameters provided for builtin type "
-                 "\"\e[1mpid\e[0m\".\n"
-                 "  Expected \e[0;32m1\e[0m, but got \e[0;31m42\e[0m.\n\e[0m">>,
+                 "  Wrong number of type parameters provided for builtin "
+                 "type \"\e[1mpid\e[0m\".\n"
+                 "  Expected \e[38;2;77;172;38m1\e[0m, but got "
+                 "\e[38;2;208;28;139m42\e[0m.\n\e[0m">>,
     ?assertEqual(Expected, Msg).
 
 

--- a/src/alpaca_error_format.erl
+++ b/src/alpaca_error_format.erl
@@ -5,7 +5,7 @@
 %%%
 %%%     http://www.apache.org/licenses/LICENSE-2.0
 %%%
-% Unless required by applicable law or agreed to in writing, software
+                                                % Unless required by applicable law or agreed to in writing, software
 %%% distributed under the License is distributed on an "AS IS" BASIS,
 %%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %%% See the License for the specific language governing permissions and
@@ -22,70 +22,78 @@
 
 %% number of lines to show before or after the errorrous line
 -define(CTX_AREA, 2).
+-define(RE_OPTS, [{return, binary}, unicode, ucp]).
 
 %% This function expects all strings passed in to it as part of error messages
 %% (e.g. function names) to be valid unicode strings.
 -spec fmt({error, term()}, Locale::string()) -> binary().
 fmt({error, {parse_error, F, Line, E}}, Locale) ->
     File = unicode:characters_to_binary(F, utf8),
-    {Msg, H} = case fmt_parse_error(E, Locale) of
-                   {MsgC, HC} ->
-                       {MsgC, HC};
-                   MsgC ->
-                       {MsgC, ""}
-               end,
+    {Msg, HlFn} = case fmt_parse_error(E, Locale) of
+                      {MsgC, HlFnC} ->
+                          {MsgC, HlFnC};
+                      MsgC ->
+                          {MsgC, hl_fn("")}
+                  end,
+    MsgI = ident(Msg),
     SourceDir = filename:dirname(File),
     Module = filename:rootname(filename:basename(File)),
     FileLine = case File of
                    <<"<no file>">> ->
-                       cf:format("~!_c~s~!!:~!c~p~!!", [File, Line]);
+                       cf("~!_c~s~!!:~!c~p~!!", [File, Line]);
                    _ ->
-                       cf:format("~!__~s/~!_c~s.alp~!!:~!c~p~!!",
-                                 [SourceDir, Module, Line])
+                       cf("~!__~s/~!_c~s~!!~!__.alp~!!:~!c~p~!!",
+                          [SourceDir, Module, Line])
                end,
-    Err = case get_context(SourceDir, Module, Line, hl_fn(H)) of
-              "" ->
-                  cf:format("~s~n  ~s~n",
-                            [FileLine, Msg]);
-              Ctx ->
-                  cf:format("~s~n  ~s~n~n"
-                            "~s~n", [FileLine, Msg, Ctx])
-          end,
-    unicode:characters_to_binary(Err, utf8);
+    case get_context(SourceDir, Module, Line, HlFn) of
+        "" ->
+            cf("~s~n~s~n", [FileLine, MsgI]);
+        Ctx ->
+            cf("~s~n~s~n~n~s~n", [FileLine, MsgI, Ctx])
+    end;
+
 fmt({error, Err}, Locale) ->
     Msg = fmt_parse_error(Err, Locale),
     <<Msg/binary, "\n"/utf8>>.
 
+ident(S) ->
+    re:replace(S, "^", "  ", [multiline, global | ?RE_OPTS]).
+
 fmt_parse_error({duplicate_definition, Id}, Locale) ->
-    t(__(<<"duplicate_definition %(id)">>), Locale, [{id, Id}]);
+    t(__(<<"duplicate_definition %(id)">>), Locale, [{id, red(Id)}]);
 fmt_parse_error({duplicate_type, Id}, Locale) ->
-    t(__(<<"duplicate_type_definition %(id)">>), Locale, [{id, Id}]);
+    t(__(<<"duplicate_type_definition %(id)">>), Locale, [{id, red(Id)}]);
 fmt_parse_error({function_not_exported, Mod, Name}, Locale) ->
-    t(__(<<"function_not_exported %(mod) %(name)">>), Locale,
-      [{'fun', Name}, {mod, atom_to_binary(Mod, utf8)}]);
+    t(__(<<"function_not_exported %(mod) %(fun)">>), Locale,
+      [{'fun', red(Name)}, {mod, bold(atom_to_binary(Mod, utf8))}]);
 fmt_parse_error({invalid_bin_qualifier, Str}, Locale) ->
-    t(__(<<"invalid_bin_qualifier %(qualifier)">>), Locale, [{qualifier, Str}]);
+    t(__(<<"invalid_bin_qualifier %(qualifier)">>), Locale,
+      [{qualifier, red(Str)}]);
 fmt_parse_error({invalid_bin_type, Str}, Locale) ->
-    t(__(<<"invalid_bin_type %(type)">>), Locale, [{type, Str}]);
+    t(__(<<"invalid_bin_type %(type)">>), Locale,
+      [{type, red(Str)}]);
 fmt_parse_error({invalid_endianness, Str}, Locale) ->
-    t(__(<<"invalid_endianness %(endianness)">>), Locale, [{endianness, Str}]);
+    t(__(<<"invalid_endianness %(endianness)">>), Locale,
+      [{endianness, red(Str)}]);
 fmt_parse_error({invalid_fun_parameter, _}, Locale) ->
     t(__(<<"invalid_fun_parameter">>), Locale);
 fmt_parse_error({invalid_top_level_construct, _}, Locale) ->
     t(__(<<"invalid_top_level_construct">>), Locale);
 fmt_parse_error({module_rename, Old, New}, Locale) ->
     t(__(<<"module_rename %(old) %(new).">>), Locale,
-      [{old, atom_to_binary(Old, utf8)}, {new, atom_to_binary(New, utf8)}]);
+      [{old, green(atom_to_binary(Old, utf8))},
+       {new, red(atom_to_binary(New, utf8))}]);
 fmt_parse_error(no_module, Locale) ->
     t(__(<<"no_module">>), Locale);
 fmt_parse_error({no_module, Mod}, Locale) when is_atom(Mod) ->
-    t(__(<<"no_module %(mod)">>), Locale, [{mod, atom_to_binary(Mod, utf8)}]);
+    fmt_parse_error({no_module, atom_to_binary(Mod, utf8)}, Locale);
 fmt_parse_error({no_module, Mod}, Locale) ->
-    t(__(<<"no_module %(mod)">>), Locale, [{mod, Mod}]);
+    t(__(<<"no_module %(mod)">>), Locale, [{mod, red(Mod)}]);
 fmt_parse_error({syntax_error, ""}, Locale) ->
     t(__(<<"incomplete_expression">>), Locale);
 fmt_parse_error({syntax_error, Token}, Locale) ->
-    t(__(<<"unexpected_token %(token)">>), Locale, [{token, Token}]);
+    {t(__(<<"unexpected_token %(token)">>), Locale,
+       [{token, red(Token)}]), hl_fn(Token)};
 fmt_parse_error({wrong_type_arity, t_atom, _A}, Locale) ->
     simple_type_arity_error("atom", Locale);
 fmt_parse_error({wrong_type_arity, t_binary, _A}, Locale) ->
@@ -109,14 +117,14 @@ fmt_parse_error(Unknown, Locale) ->
 
 simple_type_arity_error(LiteralType, Locale) ->
     t(__(<<"type_parameter_given_to_primitive_builtin_type %(type)">>), Locale,
-      [{type, LiteralType}]).
+      [{type, red(LiteralType)}]).
 
 poly_type_arity_error(LiteralType, ExpectedArity, ActualArity, Locale) ->
-    t(__(<<"builtin_type_arity_error %(num_expected) %(num_supplied)">>),
+    t(__(<<"builtin_type_arity_error %(type) %(num_expected) %(num_supplied)">>),
       Locale,
-      [{type, LiteralType},
-       {num_expected, integer_to_binary(ExpectedArity)},
-       {num_supplied, integer_to_binary(ActualArity)}]).
+      [{type, bold(LiteralType)},
+       {num_expected, green(integer_to_binary(ExpectedArity))},
+       {num_supplied, red(integer_to_binary(ActualArity))}]).
 
 fmt_unknown_error(Err, Locale) ->
     t(__(<<"unknown_error %(raw_error_term)">>), Locale,
@@ -126,17 +134,17 @@ t(MsgId, Locale) ->
     t(MsgId, Locale, []).
 
 t(MsgId, Locale, Replacements) ->
-  Translated = case epo_gettext:gettext(alpaca_compiled_po, MsgId, Locale) of
-      MsgId -> epo_gettext:gettext(alpaca_compiled_po, MsgId, "en_US");
-      Translation -> Translation
-  end,
-  replace(Translated, Replacements).
+    Translated = case epo_gettext:gettext(alpaca_compiled_po, MsgId, Locale) of
+                     MsgId -> epo_gettext:gettext(alpaca_compiled_po, MsgId, "en_US");
+                     Translation -> Translation
+                 end,
+    replace(Translated, Replacements).
 
 replace(TranslatedStr, Replacements) ->
-  lists:foldl(fun({FromAtom, To}, Str) ->
-    FromStr = "%\\(" ++ atom_to_list(FromAtom) ++ "\\)",
-    re:replace(Str, FromStr, To, [global, unicode, {return, binary}])
-  end, TranslatedStr, Replacements).
+    lists:foldl(fun({FromAtom, To}, Str) ->
+                        FromStr = "%\\(" ++ atom_to_list(FromAtom) ++ "\\)",
+                        re:replace(Str, FromStr, To, [global | ?RE_OPTS])
+                end, TranslatedStr, Replacements).
 
 
 get_context(SourceDir, Module, Target, Fn) ->
@@ -170,14 +178,24 @@ read_lines(Device, Line, Target, Fn, Acc) ->
         Txt ->
             L1 = case Line of
                      Target ->
-                         cf:format("~!r~4b~!!: ~s", [Line, Fn(Txt)]);
-                      _ ->
-                         cf:format("~!c~4b~!!: ~s", [Line, Txt])
-                  end,
+                         cf("~!r~4b~!!: ~s", [Line, Fn(Txt)]);
+                     _ ->
+                         cf("~!c~4b~!!: ~s", [Line, Txt])
+                 end,
             read_lines(Device, Line + 1, Target, Fn, [L1 | Acc])
     end.
 
+red(S) ->
+    cf("~!r~s", [S]).
 
+green(S) ->
+    cf("~!g~s", [S]).
+
+bold(S) ->
+    cf("~!^~s", [S]).
+
+cf(Fmt, Args) ->
+    unicode:characters_to_binary(cf:format(Fmt, Args), utf8).
 
 %% Helper function to generate a 'highlighter' to display syntax errors
 %% in line.
@@ -186,10 +204,10 @@ hl_fn("") ->
             X
     end;
 hl_fn(O) ->
-    P = re:replace(O, "[.^$*+?()[{\\\|\s#]", "\\\\&", [global]),
+    P = re:replace(O, "[.^$*+?()[{\\\|\s#]", "\\\\&", [global | ?RE_OPTS]),
     R = list_to_binary(cf:format("~!r~s", [O])),
     fun(L) ->
-            re:replace(L, ["(.*)", P, "(.*?)$"], ["\\1", R, "\\2"])
+            re:replace(L, ["(.*)", P, "(.*?)$"], ["\\1", R, "\\2"], [?RE_OPTS])
     end.
 
 -ifdef(TEST).
@@ -201,43 +219,113 @@ test_fmt(Error) ->
     R = fmt(Error, "en_US"),
     application:set_env(cf, colour_term, CF),
     R.
+
+test_fmt_c(Error) ->
+    CF = application:get_env(cf, colour_term),
+    application:set_env(cf, colour_term, true),
+    R = fmt(Error, "en_US"),
+    application:set_env(cf, colour_term, CF),
+    R.
 fmt_unknown_parse_error_test() ->
-  File = "/tmp/file.alp",
-  Line = 10,
-  ParseError = unknown,
-  Error = {error, {parse_error, File, Line, ParseError}},
-  Msg = test_fmt(Error),
-  Expected = <<"/tmp/file.alp:10\n  unknown\n"
-               "Sorry, we do not have a proper message for this error yet.\n"
-               "Please consider filing an issue at "
-               "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,
-  ?assertEqual(Expected, Msg).
+    File = "/tmp/file.alp",
+    Line = 10,
+    ParseError = unknown,
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt(Error),
+    Expected = <<"/tmp/file.alp:10\n"
+                 "  unknown\n"
+                 "  Sorry, we do not have a proper message for this error yet.\n"
+                 "  Please consider filing an issue at "
+                 "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,
+    ?assertEqual(Expected, Msg).
 
 fmt_unknown_error_test() ->
     application:set_env(cf, colour_term, false),
-  Error = {error, unknown},
-  Msg = test_fmt(Error),
-  Expected = <<"unknown\n"
-               "Sorry, we do not have a proper message for this error yet.\n"
-               "Please consider filing an issue at "
-               "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,
-  ?assertEqual(Expected, Msg).
+    Error = {error, unknown},
+    Msg = test_fmt(Error),
+    Expected = <<"unknown\n"
+                 "Sorry, we do not have a proper message for this error yet.\n"
+                 "Please consider filing an issue at "
+                 "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,
+    ?assertEqual(Expected, Msg).
 
 en_us_fallback_test() ->
-  File = "/tmp/file.alp",
-  Line = 10,
-  ParseError = {syntax_error, "blah"},
-  Error = {error, {parse_error, File, Line, ParseError}},
-  Msg = test_fmt(Error),
-  Expected = <<"/tmp/file.alp:10\n  Syntax error before \"blah\".\n">>,
-  ?assertEqual(Expected, Msg).
+    File = "/tmp/file.alp",
+    Line = 10,
+    ParseError = {syntax_error, "blah"},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt(Error),
+    Expected = <<"/tmp/file.alp:10\n"
+                 "  Syntax error before \"blah\".\n">>,
+    ?assertEqual(Expected, Msg).
+
+en_us_syntax_color_test() ->
+    File = "/tmp/file.alp",
+    Line = 10,
+    ParseError = {syntax_error, "blah"},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt_c(Error),
+    Expected = <<"\e[4m/tmp/\e[0;36m\e[4mfile\e[0m\e[4m.alp\e[0m:\e[0;36m10"
+                 "\e[0m\e[0m\n"
+                 "  Syntax error before \"\e[0;31mblah\e[0m\".\n\e[0m">>,
+    ?assertEqual(Expected, Msg).
+
+function_not_exported_test() ->
+    File = "/tmp/module.alp",
+    Line = 10,
+    ParseError = {function_not_exported, module, <<"fun">>},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt(Error),
+    Expected = <<"/tmp/module.alp:10\n"
+                 "  No function \"fun\" exported from module \"module\".\n">>,
+    ?assertEqual(Expected, Msg).
+
+function_not_exported_c_test() ->
+    File = "/tmp/module.alp",
+    Line = 10,
+    ParseError = {function_not_exported, module, <<"fun">>},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt_c(Error),
+    Expected = <<"\e[4m/tmp/\e[0;36m\e[4mmodule\e[0m\e[4m.alp\e[0m:"
+                 "\e[0;36m10\e[0m\e[0m\n"
+                 "  No function \"\e[0;31mfun\e[0m\" "
+                 "exported from module \"\e[1mmodule\e[0m\".\n\e[0m">>,
+    ?assertEqual(Expected, Msg).
+
+buildin_type_arity_test() ->
+    File = "/tmp/module.alp",
+    Line = 10,
+    ParseError = {wrong_type_arity, t_pid, 42},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt(Error),
+    Expected = <<"/tmp/module.alp:10\n"
+                 "  Wrong number of type parameters provided for builtin type ",
+                 "\"pid\".\n"
+                 "  Expected 1, but got 42.\n">>,
+    ?assertEqual(Expected, Msg).
+
+buildin_type_arity_c_test() ->
+    File = "/tmp/module.alp",
+    Line = 10,
+    ParseError = {wrong_type_arity, t_pid, 42},
+    Error = {error, {parse_error, File, Line, ParseError}},
+    Msg = test_fmt_c(Error),
+    Expected = <<"\e[4m/tmp/\e[0;36m\e[4mmodule\e[0m\e[4m.alp\e[0m:"
+                 "\e[0;36m10\e[0m\e[0m\n"
+                 "  Wrong number of type parameters provided for builtin type "
+                 "\"\e[1mpid\e[0m\".\n"
+                 "  Expected \e[0;32m1\e[0m, but got \e[0;31m42\e[0m.\n\e[0m">>,
+    ?assertEqual(Expected, Msg).
+
+
 
 real_error_test() ->
-  Source = "let add a b = a + b",
-  Error = {error, _}  = alpaca:compile({text, Source}),
-  Msg = test_fmt(Error),
-  Expected = <<"<no file>:1\n  No module name defined.\n"
-               "You may define it like this: \"module foo\".\n">>,
-  ?assertEqual(Expected, Msg).
+    Source = "let add a b = a + b",
+    Error = {error, _}  = alpaca:compile({text, Source}),
+    Msg = test_fmt(Error),
+    Expected = <<"<no file>:1\n"
+                 "  No module name defined.\n"
+                 "  You may define it like this: \"module foo\".\n">>,
+    ?assertEqual(Expected, Msg).
 
 -endif.

--- a/src/alpaca_error_format.erl
+++ b/src/alpaca_error_format.erl
@@ -5,7 +5,7 @@
 %%%
 %%%     http://www.apache.org/licenses/LICENSE-2.0
 %%%
-                                                % Unless required by applicable law or agreed to in writing, software
+%%% Unless required by applicable law or agreed to in writing, software
 %%% distributed under the License is distributed on an "AS IS" BASIS,
 %%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %%% See the License for the specific language governing permissions and
@@ -40,16 +40,16 @@ fmt({error, {parse_error, F, Line, E}}, Locale) ->
     Module = filename:rootname(filename:basename(File)),
     FileLine = case File of
                    <<"<no file>">> ->
-                       cf("~!_c~s~!!:~!c~p~!!", [File, Line]);
+                       cf("~!_c~ts~!!:~!c~p~!!", [File, Line]);
                    _ ->
-                       cf("~!__~s/~!_c~s~!!~!__.alp~!!:~!c~p~!!",
+                       cf("~!__~ts/~!_c~ts~!!~!__.alp~!!:~!c~p~!!",
                           [SourceDir, Module, Line])
                end,
     case get_context(SourceDir, Module, Line, HlFn) of
         "" ->
-            cf("~s~n~s~n", [FileLine, MsgI]);
+            cf("~ts~n~ts~n", [FileLine, MsgI]);
         Ctx ->
-            cf("~s~n~s~n~n~s~n", [FileLine, MsgI, Ctx])
+            cf("~ts~n~ts~n~n~ts~n", [FileLine, MsgI, Ctx])
     end;
 
 fmt({error, Err}, Locale) ->
@@ -113,7 +113,8 @@ fmt_parse_error({wrong_type_arity, t_pid, A}, Locale) ->
 fmt_parse_error({wrong_type_arity, t_string, _A}, Locale) ->
     simple_type_arity_error("string", Locale);
 fmt_parse_error(Unknown, Locale) ->
-    fmt_unknown_error(Unknown, Locale).
+    E = fmt_unknown_error(Unknown, Locale),
+    <<"(╯°□°）╯︵ ┻━┻ "/utf8, E/binary>>.
 
 simple_type_arity_error(LiteralType, Locale) ->
     t(__(<<"type_parameter_given_to_primitive_builtin_type %(type)">>), Locale,
@@ -148,7 +149,7 @@ replace(TranslatedStr, Replacements) ->
 
 
 get_context(SourceDir, Module, Target, Fn) ->
-    case file:open(io_lib:format("~s/~s.alp", [SourceDir, Module]),
+    case file:open(io_lib:format("~ts/~ts.alp", [SourceDir, Module]),
                    [read, binary]) of
         {ok, Device} ->
             read_lines(Device, 1, Target, Fn, []);
@@ -178,24 +179,25 @@ read_lines(Device, Line, Target, Fn, Acc) ->
         Txt ->
             L1 = case Line of
                      Target ->
-                         cf("  ~!r~4b~!!: ~s", [Line, Fn(Txt)]);
+                         cf("  ~!r~4b~!!: ~ts", [Line, Fn(Txt)]);
                      _ ->
-                         cf("  ~!c~4b~!!: ~s", [Line, Txt])
+                         cf("  ~!c~4b~!!: ~ts", [Line, Txt])
                  end,
             read_lines(Device, Line + 1, Target, Fn, [L1 | Acc])
     end.
 
 red(S) ->
-    cf("~!r~s", [S]).
+    cf("~!r~ts", [S]).
 
 green(S) ->
-    cf("~!g~s", [S]).
+    cf("~!g~ts", [S]).
 
 bold(S) ->
-    cf("~!^~s", [S]).
+    cf("~!^~ts", [S]).
 
 cf(Fmt, Args) ->
     unicode:characters_to_binary(cf:format(Fmt, Args), utf8).
+
 
 %% Helper function to generate a 'highlighter' to display syntax errors
 %% in line.
@@ -205,7 +207,7 @@ hl_fn("") ->
     end;
 hl_fn(O) ->
     P = re:replace(O, "[.^$*+?()[{\\\|\s#]", "\\\\&", [global | ?RE_OPTS]),
-    R = list_to_binary(cf:format("~!r~s", [O])),
+    R = list_to_binary(cf:format("~!r~ts", [O])),
     fun(L) ->
             re:replace(L, ["(.*)", P, "(.*?)$"], ["\\1", R, "\\2"], [?RE_OPTS])
     end.
@@ -232,8 +234,8 @@ fmt_unknown_parse_error_test() ->
     ParseError = unknown,
     Error = {error, {parse_error, File, Line, ParseError}},
     Msg = test_fmt(Error),
-    Expected = <<"/tmp/file.alp:10\n"
-                 "  unknown\n"
+    Expected = <<"/tmp/file.alp:10\n",
+                 "  (╯°□°）╯︵ ┻━┻ "/utf8, "unknown\n"
                  "  Sorry, we do not have a proper message for this error yet.\n"
                  "  Please consider filing an issue at "
                  "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,
@@ -243,7 +245,7 @@ fmt_unknown_error_test() ->
     application:set_env(cf, colour_term, false),
     Error = {error, unknown},
     Msg = test_fmt(Error),
-    Expected = <<"unknown\n"
+    Expected = <<"(╯°□°）╯︵ ┻━┻ "/utf8, "unknown\n"
                  "Sorry, we do not have a proper message for this error yet.\n"
                  "Please consider filing an issue at "
                  "https://www.github.com/alpaca-lang/alpaca/issues.\n">>,

--- a/src/alpaca_error_format.erl
+++ b/src/alpaca_error_format.erl
@@ -178,9 +178,9 @@ read_lines(Device, Line, Target, Fn, Acc) ->
         Txt ->
             L1 = case Line of
                      Target ->
-                         cf("~!r~4b~!!: ~s", [Line, Fn(Txt)]);
+                         cf("  ~!r~4b~!!: ~s", [Line, Fn(Txt)]);
                      _ ->
-                         cf("~!c~4b~!!: ~s", [Line, Txt])
+                         cf("  ~!c~4b~!!: ~s", [Line, Txt])
                  end,
             read_lines(Device, Line + 1, Target, Fn, [L1 | Acc])
     end.

--- a/test/error.alp
+++ b/test/error.alp
@@ -1,0 +1,20 @@
+module alpaca_format
+
+export format/1
+
+import_type alpaca_native_ast.ast
+
+import_type alpaca_native_ast.symbol
+
+let format ast_node = format_ast 0 ast_node
+
+let max_len = = 80
+
+let format_ast depth Symbol {name=name} =
+  let end_of_line = depth + (s_len name) in
+  (end_of_line, name)
+
+--format depth Apply (sym, _) =
+
+let s_len s = beam :string :len [s] with
+  l, is_integer l -> l


### PR DESCRIPTION
WIP for nicer errors.

**Work In Progress don't merge!**

Goals:

- [x] Include source where possible.
- [x] Highlight syntax errors.
- [x] Do some general pretty coloury thingies.
- [x] Do some pretty coloury thingies for messages themsefls.
- [x] Ensure indenting
The schema / rules used is the following:

We avoid bold colours as they can seem intimidating, with the exception of parts we **really** want people to see.

* Filenames are underlined.
* Module are cyan
* line number are cyan with the exception of the errors line number in code snippets
* Errors are red
* 'Good' data is green.
* Important information that is neither error not 'good' is bold.
* Filename/line-number are in one line separated by a `:` so editors can understand that.
* Error messages are on the following line, indented by two spaces
* Code is indented 6 spaces (or rather the number is 4 spaces 'wide' and is always indented 2 more spaces)
* Whenever possible the code snipped is included in the error with the two surrounding lines.

Or in an example (please forgive the horrible yellow arrows):
![image](https://user-images.githubusercontent.com/119093/27139358-0ff3bb0c-5123-11e7-8be7-84c4cb9c2f33.png)

1) the module name part of the file.
2) the line number the error occurred in
3) both lines are indented by 2 spaces
4) We're dealing with a PID, this is important info but not an error
5) We would have liked arity 1
6) We got arity 42

Code is included and on syntax errors the offending syntax is highlighted:
![image](https://user-images.githubusercontent.com/119093/27141000-52da1b2e-5127-11e7-9783-554ad05e360c.png)
