### PR TITLE
Add && and ||

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,10 @@
 {dialyzer, [{warnings, [unknown]}]}.
 
 {profiles, [
+            {shell, [
+                    {deps, [sync]}
+                   ]},
+
             {test, [
                     {deps, [proper]}
                    ]}

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -291,6 +291,7 @@ term_line(Term) ->
         {_, L} when is_integer(L) -> L;
         {_, L, _} when is_integer(L) -> L;
         {C, Map}=ADT when is_atom(C), is_map(Map) -> alpaca_ast:line(ADT);
+        {raise_error, L, _, _} -> L;
         {bif, _, L, _, _} -> L;
         #alpaca_apply{line=L} -> L;
         #alpaca_cons{line=L} -> L;

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -854,6 +854,17 @@ bif_infix_test() ->
     ?assertEqual(false, run_expr("true and false")),
     ?assertEqual(true,  run_expr("true and true")),
 
+
+    %% (&&) -> logical and short circute
+    ?assertEqual(false, run_expr("false && false")),
+    ?assertEqual(false, run_expr("true && false")),
+    ?assertEqual(true,  run_expr("true && true")),
+
+    %% (||) -> logical and short circute
+    ?assertEqual(false, run_expr("false || false")),
+    ?assertEqual(false, run_expr("true || false")),
+    ?assertEqual(true,  run_expr("true || true")),
+
     ok.
 
 infix_fun_test() ->

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -859,11 +859,15 @@ bif_infix_test() ->
     ?assertEqual(false, run_expr("false && false")),
     ?assertEqual(false, run_expr("true && false")),
     ?assertEqual(true,  run_expr("true && true")),
+    %% prove short circuting by throwing as 2nd part of the expression
+    ?assertEqual(false, run_expr("false && (error \"oh no and failed!\")")),
 
     %% (||) -> logical and short circute
     ?assertEqual(false, run_expr("false || false")),
-    ?assertEqual(false, run_expr("true || false")),
+    ?assertEqual(true, run_expr("true || false")),
     ?assertEqual(true,  run_expr("true || true")),
+    %% prove short circuting by throwing as 2nd part of the expression
+    ?assertEqual(true, run_expr("true || (error \"oh no or failed!\")")),
 
     ok.
 

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -842,7 +842,19 @@ bif_infix_test() ->
 
     %% (<=) -> less than or equal to
     ?assertEqual(true, run_expr("5 =< 5")),
-    ?assertEqual(false, run_expr("5.1 =< 5.0")).
+    ?assertEqual(false, run_expr("5.1 =< 5.0")),
+
+    %% (||) -> logical or
+    ?assertEqual(false, run_expr(":false || :false")),
+    ?assertEqual(true,  run_expr(":true || :false")),
+    ?assertEqual(true,  run_expr(":true || :true")),
+
+    %% (&&) -> logical and
+    ?assertEqual(false, run_expr(":false && :false")),
+    ?assertEqual(false, run_expr(":true && :false")),
+    ?assertEqual(true,  run_expr(":true && :true")),
+
+    ok.
 
 infix_fun_test() ->
     Name = alpaca_infix_fun,

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -844,17 +844,6 @@ bif_infix_test() ->
     ?assertEqual(true, run_expr("5 =< 5")),
     ?assertEqual(false, run_expr("5.1 =< 5.0")),
 
-    %% (or) -> logical not short circute
-    ?assertEqual(false, run_expr("false or false")),
-    ?assertEqual(true,  run_expr("true or false")),
-    ?assertEqual(true,  run_expr("true or true")),
-
-    %% (and) -> logical and not short circute
-    ?assertEqual(false, run_expr("false and false")),
-    ?assertEqual(false, run_expr("true and false")),
-    ?assertEqual(true,  run_expr("true and true")),
-
-
     %% (&&) -> logical and short circute
     ?assertEqual(false, run_expr("false && false")),
     ?assertEqual(false, run_expr("true && false")),

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -844,15 +844,15 @@ bif_infix_test() ->
     ?assertEqual(true, run_expr("5 =< 5")),
     ?assertEqual(false, run_expr("5.1 =< 5.0")),
 
-    %% (||) -> logical or
-    ?assertEqual(false, run_expr(":false || :false")),
-    ?assertEqual(true,  run_expr(":true || :false")),
-    ?assertEqual(true,  run_expr(":true || :true")),
+    %% (or) -> logical not short circute
+    ?assertEqual(false, run_expr("false or false")),
+    ?assertEqual(true,  run_expr("true or false")),
+    ?assertEqual(true,  run_expr("true or true")),
 
-    %% (&&) -> logical and
-    ?assertEqual(false, run_expr(":false && :false")),
-    ?assertEqual(false, run_expr(":true && :false")),
-    ?assertEqual(true,  run_expr(":true && :true")),
+    %% (and) -> logical and not short circute
+    ?assertEqual(false, run_expr("false and false")),
+    ?assertEqual(false, run_expr("true and false")),
+    ?assertEqual(true,  run_expr("true and true")),
 
     ok.
 

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -74,12 +74,12 @@ test
 
 boolean int float atom string chars '_'
 symbol infixl infixr '.'
-assign int_math float_math minus plus logic
+assign int_math float_math minus plus logic logic_sc
 '[' ']' cons_infix ':'
 bin_open bin_close
 open_brace close_brace
 map_open map_arrow
-match with '|' '->'
+match with '|' '->' '&&' '||'
 
 raise_error
 
@@ -481,6 +481,36 @@ tuple_list -> simple_expr ',' simple_expr : ['$1', '$3'].
 tuple_list -> simple_expr ',' tuple_list : ['$1' | '$3'].
 tuple -> '(' tuple_list ')' :
   #alpaca_tuple{arity=length('$2'), values='$2'}.
+
+infix -> term '&&' term :
+         L1 = term_line('$1'),
+         L2 = term_line('$3'),
+         FalseC = #alpaca_clause{
+                     pattern={boolean, L1, false},
+                     result={boolean, L1, false}, line=L1},
+         TrueC = #alpaca_clause{
+                    pattern={boolean, L2, true},
+                    result='$3', line=L2},
+         #alpaca_match{
+            match_expr='$1',
+            clauses=[TrueC, FalseC],
+            line=L1
+           }.
+
+infix -> term '||' term :
+         L1 = term_line('$1'),
+         L2 = term_line('$3'),
+         TrueC = #alpaca_clause{
+                     pattern={boolean, L1, true},
+                     result={boolean, L1, true}, line=L1},
+         FalseC = #alpaca_clause{
+                    pattern={boolean, L2, false},
+                    result='$3', line=L2},
+         #alpaca_match{
+            match_expr='$1',
+            clauses=[TrueC, FalseC],
+            line=L1
+           }.
 
 infix -> term op term : make_infix('$2', '$1', '$3').
 

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -74,7 +74,7 @@ test
 
 boolean int float atom string chars '_'
 symbol infixl infixr '.'
-assign int_math float_math minus plus
+assign int_math float_math minus plus logic
 '[' ']' cons_infix ':'
 bin_open bin_close
 open_brace close_brace
@@ -318,6 +318,7 @@ op -> float_math : '$1'.
 op -> minus : '$1'.
 op -> plus : '$1'.
 op -> '/' : '$1'.
+op -> logic : '$1'.
 
 const -> boolean : '$1'.
 
@@ -752,6 +753,10 @@ make_infix(Op, A, B) ->
                    alpaca_ast:symbol(L, infix_name(C));
 
       {int_math, L, "%"} -> {bif, '%', L, erlang, 'rem'};
+
+      {logic, L, "||"} -> {bif, '||', L, erlang, 'or'};
+      {logic, L, "&&"} -> {bif, '&&', L, erlang, 'and'};
+
       {minus, L} -> {bif, '-', L, erlang, '-'};
       {plus, L} -> {bif, '+', L, erlang, '+'};
       {int_math, L, OpString} ->

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -784,9 +784,6 @@ make_infix(Op, A, B) ->
 
       {int_math, L, "%"} -> {bif, '%', L, erlang, 'rem'};
 
-      {logic, L, "or"} -> {bif, 'or', L, erlang, 'or'};
-      {logic, L, "and"} -> {bif, 'and', L, erlang, 'and'};
-
       {minus, L} -> {bif, '-', L, erlang, '-'};
       {plus, L} -> {bif, '+', L, erlang, '+'};
       {int_math, L, OpString} ->

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -754,8 +754,8 @@ make_infix(Op, A, B) ->
 
       {int_math, L, "%"} -> {bif, '%', L, erlang, 'rem'};
 
-      {logic, L, "||"} -> {bif, '||', L, erlang, 'or'};
-      {logic, L, "&&"} -> {bif, '&&', L, erlang, 'and'};
+      {logic, L, "or"} -> {bif, 'or', L, erlang, 'or'};
+      {logic, L, "and"} -> {bif, 'and', L, erlang, 'and'};
 
       {minus, L} -> {bif, '-', L, erlang, '-'};
       {plus, L} -> {bif, '+', L, erlang, '+'};

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -132,10 +132,11 @@ c"(\\"*|\\.|[^"\\])*" :
 \+ : {token, {plus, TokenLine}}.
 
 
-
 [\*\/\%]   : {token, {int_math, TokenLine, TokenChars}}.
 {FLOAT_MATH} : {token, {float_math, TokenLine, TokenChars}}.
 ->       : {token, {'->', TokenLine}}.
+&&       : {token, {'&&', TokenLine}}.
+\|\|       : {token, {'&&', TokenLine}}.
 \x{2192} : {token, {'->', TokenLine}}.          % unicode rightwards arrow
 _        : {token, {'_', TokenLine}}.
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -71,7 +71,6 @@ receive     : {token, {'receive', TokenLine}}.
 after       : {token, {'after', TokenLine}}.
 test        : {token, {'test', TokenLine}}.
 error|exit|throw : {token, {'raise_error', TokenLine, TokenChars}}.
-and|or     : {token, {logic, TokenLine, TokenChars}}.
 
 true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -136,7 +136,7 @@ c"(\\"*|\\.|[^"\\])*" :
 {FLOAT_MATH} : {token, {float_math, TokenLine, TokenChars}}.
 ->       : {token, {'->', TokenLine}}.
 &&       : {token, {'&&', TokenLine}}.
-\|\|       : {token, {'&&', TokenLine}}.
+\|\|       : {token, {'||', TokenLine}}.
 \x{2192} : {token, {'->', TokenLine}}.          % unicode rightwards arrow
 _        : {token, {'_', TokenLine}}.
 

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -71,6 +71,7 @@ receive     : {token, {'receive', TokenLine}}.
 after       : {token, {'after', TokenLine}}.
 test        : {token, {'test', TokenLine}}.
 error|exit|throw : {token, {'raise_error', TokenLine, TokenChars}}.
+and|or     : {token, {logic, TokenLine, TokenChars}}.
 
 true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 
@@ -133,7 +134,6 @@ c"(\\"*|\\.|[^"\\])*" :
 
 
 [\*\/\%]   : {token, {int_math, TokenLine, TokenChars}}.
-&&|\|\|    : {token, {logic, TokenLine, TokenChars}}.
 {FLOAT_MATH} : {token, {float_math, TokenLine, TokenChars}}.
 ->       : {token, {'->', TokenLine}}.
 \x{2192} : {token, {'->', TokenLine}}.          % unicode rightwards arrow

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -20,8 +20,8 @@ D   = [0-9]
 L   = [a-z]
 U   = [A-Z]
 SYM = {L}[a-zA-Z0-9_]*
-O  = [\.\*<>\|\$~\^=\?\+@%/]
-OL = [\.\*>\|\$~\^=\?\+@%/]
+O  = [\.\*<>\|\$~\^=\?\+@%/&]
+OL = [\.\*>\|\$~\^=\?\+@%/&]
 OR = [<]
 OPR = {OR}{O}*
 OPL = {OL}{O}*
@@ -133,6 +133,7 @@ c"(\\"*|\\.|[^"\\])*" :
 
 
 [\*\/\%]   : {token, {int_math, TokenLine, TokenChars}}.
+&&|\|\|    : {token, {logic, TokenLine, TokenChars}}.
 {FLOAT_MATH} : {token, {float_math, TokenLine, TokenChars}}.
 ->       : {token, {'->', TokenLine}}.
 \x{2192} : {token, {'->', TokenLine}}.          % unicode rightwards arrow
@@ -192,6 +193,3 @@ unescape([$\\, Char | Rest], Acc) ->
     _ -> unescape(Rest, [Res | Acc])
   end;
 unescape([C | Rest], Acc) -> unescape(Rest, [C | Acc]).
-
-
-

--- a/src/builtin_types.hrl
+++ b/src/builtin_types.hrl
@@ -15,7 +15,9 @@
 %%% See the License for the specific language governing permissions and
 %%% limitations under the License.
 
--define(all_bifs, [?t_int_add, ?t_int_sub,
+-define(all_bifs, [?t_logic_and, ?t_logic_or,
+
+                   ?t_int_add, ?t_int_sub,
                    ?t_int_mul, ?t_int_div, ?t_int_rem,
                    ?t_float_add, ?t_float_sub,
                    ?t_float_mul, ?t_float_div,
@@ -23,6 +25,12 @@
                    ?t_equality, ?t_neq,
                    ?t_gt, ?t_lt, ?t_gte, ?t_lte
                   ]).
+
+
+-define(t_logic,     {t_arrow, [t_bool, t_bool], t_bool}).
+
+-define(t_logic_and, {'&&', ?t_logic}).
+-define(t_logic_or,  {'||', ?t_logic}).
 
 -define(t_int_math, {t_arrow, [t_int, t_int], t_int}).
 

--- a/src/builtin_types.hrl
+++ b/src/builtin_types.hrl
@@ -15,8 +15,7 @@
 %%% See the License for the specific language governing permissions and
 %%% limitations under the License.
 
--define(all_bifs, [?t_logic_and, ?t_logic_or,
-
+-define(all_bifs, [
                    ?t_int_add, ?t_int_sub,
                    ?t_int_mul, ?t_int_div, ?t_int_rem,
                    ?t_float_add, ?t_float_sub,
@@ -25,12 +24,6 @@
                    ?t_equality, ?t_neq,
                    ?t_gt, ?t_lt, ?t_gte, ?t_lte
                   ]).
-
-
--define(t_logic,     {t_arrow, [t_bool, t_bool], t_bool}).
-
--define(t_logic_and, {'and', ?t_logic}).
--define(t_logic_or,  {'or', ?t_logic}).
 
 -define(t_int_math, {t_arrow, [t_int, t_int], t_int}).
 

--- a/src/builtin_types.hrl
+++ b/src/builtin_types.hrl
@@ -29,8 +29,8 @@
 
 -define(t_logic,     {t_arrow, [t_bool, t_bool], t_bool}).
 
--define(t_logic_and, {'&&', ?t_logic}).
--define(t_logic_or,  {'||', ?t_logic}).
+-define(t_logic_and, {'and', ?t_logic}).
+-define(t_logic_or,  {'or', ?t_logic}).
 
 -define(t_int_math, {t_arrow, [t_int, t_int], t_int}).
 


### PR DESCRIPTION
This adds `||` and `&&` linking to `erlang:or` and `erlang:and` related to #97 