### PR TITLE
Add type signatures

### DIFF
--- a/Tour.md
+++ b/Tour.md
@@ -369,7 +369,7 @@ Most of the time, you can safely omit type signatures. They can be useful in get
 
 By forcing `print_string` to take only strings, we guard against passing types that Erlang's `io:put_chars` can't understand, preventing a runtime error.
 
-While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
+While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign function interface here to call an Erlang io function:
 
     let print_hello () =
       beam :io :format ["Hello~n", []] with _ -> ()

--- a/Tour.md
+++ b/Tour.md
@@ -348,7 +348,32 @@ As Alpaca is an expression-oriented language, there are no return statements.  J
     -}
     let double x = x *. 2.0
 
-Explicit type specifications for variables and functions is a planned feature for version 0.3.0.
+Type signatures can be set on top level functions and values, e.g.:
+
+    val add : fn int int -> int
+    let add x y = x + y
+
+The signatures look a little different to the other MLs, while resembling OCaml the most; they are consistent with Alpaca's type definitions in ADTs. Another example, demonstrating polymorphic parameters:
+
+    val apply 'a 'b : fn (fn 'a -> 'b) a -> 'b
+    let apply f x = f x
+
+Note the explicit listing of type variables `'a` and `'b` after the name of the signature, and that arguments are not separated by `->` but listed simply with a space between them, with the arguments separated from the return type by a single `->`. For fairly exhaustive examples of type signatures, please see `basic_signature_test.alp` in the test suite.
+
+Most of the time, you can safely omit type signatures. They can be useful in getting early feedback from the compiler that your types infer as you expect. They are also useful in making generic, unbounded functions and types more specific (specialization). They are essential when writing functions that wrap `beam` FFI calls, where the inputs are always unbounded, e.g:
+
+    val print_string : fn string -> unit
+    let print_string str =
+      beam :io :put_chars [str] with
+      | _ -> ()
+
+By forcing `print_string` to take only strings, we guard against passing types that Erlang's `io:put_chars` can't understand, preventing a runtime error.
+
+While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
+
+    let print_hello () =
+      beam :io :format ["Hello~n", []] with _ -> ()
+
 
 While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
 

--- a/Tour.md
+++ b/Tour.md
@@ -374,12 +374,6 @@ While functions with no arguments aren't supported ("nullary" or arity of zero) 
     let print_hello () =
       beam :io :format ["Hello~n", []] with _ -> ()
 
-
-While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
-
-    let print_hello () =
-      beam :io :format ["Hello~n", []] with _ -> ()
-
 ## The Foreign Function Interface<a id="sec-4-1" name="sec-4-1"></a>
 
 The FFI is how we call any non-Alpaca code in the Erlang VM (e.g. Erlang, [Elixir](http://elixir-lang.org/), [LFE](http://lfe.io/), and more).  Since our compiler can't type-check other languages, we combine a call to another module and function with a set of pattern match clauses to figure out what the actual type is that we're returning from it.

--- a/Tour.org
+++ b/Tour.org
@@ -280,7 +280,32 @@ As Alpaca is an expression-oriented language, there are no return statements.  J
 -}
 let double x = x *. 2.0
 #+END_SRC
-Explicit type specifications for variables and functions is a planned feature for version 0.3.0.
+Type signatures can be set on top level functions and values, e.g.:
+
+#+BEGIN_SRC
+val add : fn int int -> int
+let add x y = x + y
+#+END_SRC
+
+The signatures look a little different to the other MLs, while resembling OCaml the most; they are consistent with Alpaca's type definitions in ADTs. Another example, demonstrating polymorphic parameters:
+
+#+BEGIN_SRC
+val apply 'a 'b : fn (fn 'a -> 'b) a -> 'b
+let apply f x = f x
+#+END_SRC
+
+Note the explicit listing of type variables ~'a~ and ~'b~ after the name of the signature, and that arguments are not separated by ~->~ but listed simply with a space between them, with the arguments separated from the return type by a single ~->~. For fairly exhaustive examples of type signatures, please see ~basic_signature_test.alp~ in the test suite.
+
+Most of the time, you can safely omit type signatures. They can be useful in getting early feedback from the compiler that your types infer as you expect. They are also useful in making generic, unbounded functions and types more specific (specialization). They are essential when writing functions that wrap ~beam~ FFI calls, where the inputs are always unbounded, e.g:
+
+#+BEGIN_SRC
+val print_string : fn string -> unit
+let print_string str =
+  beam :io :put_chars [str] with
+  | _ -> ()
+#+END_SRC
+
+By forcing ~print_string~ to take only strings, we guard against passing types that Erlang's ~io:put_chars~ can't understand, preventing a runtime error.
 
 While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term ~()~ if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
 #+BEGIN_SRC

--- a/Tour.org
+++ b/Tour.org
@@ -307,7 +307,7 @@ let print_string str =
 
 By forcing ~print_string~ to take only strings, we guard against passing types that Erlang's ~io:put_chars~ can't understand, preventing a runtime error.
 
-While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term ~()~ if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
+While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term ~()~ if we don't need or want to pass anything specific.  Let's introduce the basic foreign function interface here to call an Erlang io function:
 #+BEGIN_SRC
 let print_hello () =
   beam :io :format ["Hello~n", []] with _ -> ()

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -657,6 +657,6 @@ built_in_adt_exhaustiveness_test() ->
 type_signature_test() ->
     Files = ["test_files/basic_type_signature.alp"],
     [M] = compile_and_load(Files, [test]),
-    ?assertMatch(4, M:add(2, 3)).
+    ?assertMatch(4, M:add(1, 3)).
 
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -654,4 +654,9 @@ built_in_adt_exhaustiveness_test() ->
        M1:make_export(1, <<"make_export">>)),
     pd(M1).
 
+type_signature_test() ->
+    Files = ["test_files/basic_type_signature.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(4, M:add(2, 3)).
+
 -endif.

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -488,6 +488,15 @@
          }).
 -type alpaca_fun() :: #alpaca_fun{}.
 
+-record(alpaca_type_signature, {
+          line=0 :: integer(),
+          name=undefined :: undefined | alpaca_symbol(),
+          type=undefined :: typ(),
+          vars=undefined :: list(alpaca_type_var())
+         }).
+
+-type alpaca_type_signature() :: #alpaca_type_signature{}.
+
 %% `body` remains `undefined` for top-level expressions and otherwise for
 %% things like function and variable bindings within a top-level function.
 -record(alpaca_binding, {
@@ -495,8 +504,10 @@
           name=undefined :: undefined | alpaca_symbol(),
           type=undefined :: typ(),
           bound_expr=undefined :: undefined | alpaca_expression(),
-          body=undefined :: undefined | alpaca_expression()
+          body=undefined :: undefined | alpaca_expression(),
+          signature=undefined :: alpaca_type_signature()
          }).
+
 -type alpaca_binding() :: #alpaca_binding{}.
 
 -record(alpaca_type_import, {module=undefined :: atom(),

--- a/src/alpaca_codegen.erl
+++ b/src/alpaca_codegen.erl
@@ -872,7 +872,7 @@ infix_fun_test() ->
         "export adder/1 \n\n"
         "let (|>) v f = f v\n\n"
         "let add_ten x = x + 10\n\n"
-        "let adder val = val |> add_ten",
+        "let adder v = v |> add_ten",
     {ok, _, Bin} = parse_and_gen(Code),
     {module, Name} = code:load_binary(Name, FN, Bin),
     ?assertEqual(20, Name:adder(10)),

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -84,7 +84,7 @@ match with '|' '->' '&&' '||'
 raise_error
 
 send
-receive after
+receive after receiver
 spawn
 
 beam
@@ -131,8 +131,8 @@ type_export -> export_type types_to_export :
   #alpaca_type_export{line=L, names=Names}.
 
 type_signature -> val symbol ':' sub_type_expr :
-                      {L, N} = symbol_line_name('$2'),
-                  #alpaca_type_signature{name=N, line=L, type='$4'}.
+  {L, N} = symbol_line_name('$2'),
+  #alpaca_type_signature{name=N, line=L, type='$4'}.
 
 type_signature -> val symbol type_vars ':' sub_type_expr :
   {L, N} = symbol_line_name('$2'),
@@ -176,8 +176,6 @@ poly_type -> symbol type_expressions :
       {<<"list">>, Params}           -> type_arity_error(L, t_list, Params);
       {<<"map">>, [K, V]}            -> {t_map, K, V};
       {<<"map">>, Params}            -> type_arity_error(L, t_map, Params);
-      {<<"receiver">>, [MsgT, ExpT]} -> {t_receiver, MsgT, ExpT};
-      {<<"receiver">>, Params}       -> type_arity_error(L, t_receiver, Params);
       {<<"pid">>, [T]}               -> {t_pid, T};
       {<<"pid">>, Params}            -> type_arity_error(L, t_pid, Params);
       {<<"string">>, Params}         -> type_arity_error(L, t_string, Params);
@@ -267,6 +265,14 @@ sub_type_expr -> '(' type_expr ')': '$2'.
 sub_type_expr -> fn type_expressions '->' type_expr :
 
     {t_arrow, '$2', '$4'}.
+
+sub_type_expr -> receiver type_expressions :
+    {receiver, L} = '$1',
+    case '$2' of
+        [MArg, MRet] -> {t_receiver, MArg, MRet};
+        Params       -> type_arity_error(L, t_receiver, Params)
+    end.
+
 sub_type_expr -> unit : t_unit.
 
 comma_separated_type_list -> type_expr ',' type_expr:

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -21,7 +21,7 @@ type poly_type poly_type_decl type_vars type_member type_members type_expr
 sub_type_expr type_expressions type_tuple comma_separated_type_list
 module_qualified_type module_qualified_type_name
 type_apply module_qualified_type_constructor
-type_import type_export types_to_export
+type_import type_export types_to_export type_signature
 
 test_case
 
@@ -68,7 +68,7 @@ comment_line comment_lines
 module export import
 import_type export_type
 
-type_declare type_constructor type_var
+type_declare type_constructor type_var val
 
 test
 
@@ -129,6 +129,24 @@ type_export -> export_type types_to_export :
   {_, L}  = '$1',
   Names = [symbol_name(S) || S <- '$2'],
   #alpaca_type_export{line=L, names=Names}.
+
+type_signature -> val symbol ':' sub_type_expr :
+                      {L, N} = symbol_line_name('$2'),
+                  #alpaca_type_signature{name=N, line=L, type='$4'}.
+
+type_signature -> val symbol type_vars ':' sub_type_expr :
+                      %% TODO - attach type vars to sub type_expr!!
+  {L, N} = symbol_line_name('$2'),
+  TV = make_vars_for_concrete_types('$3', L),
+  #alpaca_type_signature{name=N, line=L, type='$5', vars=TV}.
+
+type_signature -> val '(' infixl ')' ':' sub_type_expr :
+  {L, N} = symbol_line_name('$3'),
+  #alpaca_type_signature{name=N, line=L, type='$6'}.
+
+type_signature -> val '(' infixr ')' ':' sub_type_expr :
+  {L, N} = symbol_line_name('$3'),
+  #alpaca_type_signature{name=N, line=L, type='$6'}.
 
 type_expressions -> sub_type_expr : ['$1'].
 type_expressions -> sub_type_expr type_expressions : ['$1'|'$2'].
@@ -759,6 +777,7 @@ expr -> type : '$1'.
 expr -> test_case : '$1'.
 expr -> defn : '$1'.
 expr -> definfix : '$1'.
+expr -> type_signature : '$1'.
 
 %% I'm not sure these should be actually classifed as "expressions", something
 %% to revisit:
@@ -934,7 +953,11 @@ symbol_name({'Symbol', _}=S) ->
     alpaca_ast:symbol_name(S).
 
 symbol_line_name({symbol, S}) ->
-    {alpaca_ast:line(S), alpaca_ast:symbol_name(S)}.
+    {alpaca_ast:line(S), alpaca_ast:symbol_name(S)};
+symbol_line_name({infixl, L, N}) ->
+    {L, infix_name(N)};
+symbol_line_name({infixr, L, N}) ->
+    {L, infix_name(N)}.
 
 line({symbol, S}) ->
     alpaca_ast:line(S);

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -135,7 +135,6 @@ type_signature -> val symbol ':' sub_type_expr :
                   #alpaca_type_signature{name=N, line=L, type='$4'}.
 
 type_signature -> val symbol type_vars ':' sub_type_expr :
-                      %% TODO - attach type vars to sub type_expr!!
   {L, N} = symbol_line_name('$2'),
   TV = make_vars_for_concrete_types('$3', L),
   #alpaca_type_signature{name=N, line=L, type='$5', vars=TV}.
@@ -144,9 +143,19 @@ type_signature -> val '(' infixl ')' ':' sub_type_expr :
   {L, N} = symbol_line_name('$3'),
   #alpaca_type_signature{name=N, line=L, type='$6'}.
 
+type_signature -> val '(' infixl ')' type_vars ':' sub_type_expr :
+  {L, N} = symbol_line_name('$3'),
+  TV = make_vars_for_concrete_types('$5', L),
+  #alpaca_type_signature{name=N, line=L, type='$7', vars=TV}.
+
 type_signature -> val '(' infixr ')' ':' sub_type_expr :
   {L, N} = symbol_line_name('$3'),
   #alpaca_type_signature{name=N, line=L, type='$6'}.
+
+type_signature -> val '(' infixr ')' type_vars ':' sub_type_expr :
+  {L, N} = symbol_line_name('$3'),
+  TV = make_vars_for_concrete_types('$5', L),
+  #alpaca_type_signature{name=N, line=L, type='$7', vars=TV}.
 
 type_expressions -> sub_type_expr : ['$1'].
 type_expressions -> sub_type_expr type_expressions : ['$1'|'$2'].

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -69,6 +69,7 @@ import_type : {token, {import_type, TokenLine}}.
 spawn       : {token, {spawn, TokenLine}}.
 send        : {token, {send, TokenLine}}.
 receive     : {token, {'receive', TokenLine}}.
+receiver    : {token, {receiver, TokenLine}}.
 after       : {token, {'after', TokenLine}}.
 test        : {token, {'test', TokenLine}}.
 error|exit|throw : {token, {'raise_error', TokenLine, TokenChars}}.

--- a/src/alpaca_scan.xrl
+++ b/src/alpaca_scan.xrl
@@ -55,6 +55,7 @@ Rules.
 let         : {token, {'let', TokenLine}}.
 in          : {token, {in, TokenLine}}.
 fn          : {token, {fn, TokenLine}}.
+val         : {token, {val, TokenLine}}.
 \x{03BB}    : {token, {fn, TokenLine}}.         % unicode lower-case lambda
 match       : {token, {match, TokenLine}}.
 with        : {token, {with, TokenLine}}.
@@ -101,7 +102,7 @@ true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Atom
 {ATOM} : {token, {atom, TokenLine, tl(TokenChars)}}.
-{ATOM}"(\\"*|\\.|[^"\\])*" : 
+{ATOM}"(\\"*|\\.|[^"\\])*" :
   S = string:substr(TokenChars, 3, TokenLen - 3),
   {token, {atom, TokenLine, S}}.
 

--- a/src/alpaca_scanner.erl
+++ b/src/alpaca_scanner.erl
@@ -60,6 +60,7 @@ infer_breaks(Tokens) ->
             'export_type'  -> InferBreak();
             'import_type'  -> InferBreak();
             'import'       -> InferBreak();
+            'val'          -> InferBreak();
             _              -> Pass()
         end      
     end,

--- a/test_files/basic_type_signature.alp
+++ b/test_files/basic_type_signature.alp
@@ -51,3 +51,19 @@ let getName { name = n } = n
 val hd 'a : fn (list 'a) -> (maybe 'a)
 let hd [] = Nothing
 let hd (first :: _) = Just first
+
+-- Pids
+
+-- (receivers are typed with their 'receive' type and a function with its input
+--  and return value; return can also be 'rec' if it recurses infinitely)
+
+val make_receiver : receiver (int) (fn () -> int)
+let make_receiver () = receive with
+    v -> v
+
+val make_pid : fn () -> pid int
+let make_pid () = spawn make_receiver ()
+
+let run_pid () =
+    let p = make_pid () in
+    send 35 p

--- a/test_files/basic_type_signature.alp
+++ b/test_files/basic_type_signature.alp
@@ -57,7 +57,7 @@ let hd (first :: _) = Just first
 -- (receivers are typed with their 'receive' type and a function with its input
 --  and return value; return can also be 'rec' if it recurses infinitely)
 
-val make_receiver : receiver (int) (fn () -> int)
+val make_receiver : receiver int (fn () -> int)
 let make_receiver () = receive with
     v -> v
 

--- a/test_files/basic_type_signature.alp
+++ b/test_files/basic_type_signature.alp
@@ -1,0 +1,49 @@
+module basic_type_signature
+
+export add
+
+-- Primitive top level 'constant' bindings
+val name : string
+let name = "Alpaca"
+
+val birthday : int
+let birthday = 2701
+
+-- Simple functions
+val add : fn int int -> int
+let add x y = x + y
+
+-- Polymorphic functions
+val identity 'a : fn 'a -> 'a
+let identity x = x
+
+-- ADTs as params and return values
+type maybe 'a = Just 'a | Nothing
+
+val return 'a : fn 'a -> maybe 'a
+let return x = Just x
+
+-- Higher order functions
+val apply 'a 'b : fn (fn 'a -> 'b) 'a -> 'b 
+let apply f x = f x
+
+-- TODO: Infix functions (!)
+let (<|) f x = apply f x
+
+-- Concrete typing of a polymorphic ADT
+val maybeDouble : fn (maybe int) -> (maybe int)
+let maybeDouble (Just x) = return <| x * 2
+let maybeDouble Nothing = Nothing
+
+-- Tuples
+val fst 'a 'b: fn ('a, 'b) -> 'a
+let fst (x, y) = x
+
+-- Records
+val getName : fn { name : string } -> string
+let getName { name = n } = n
+
+-- Arrays
+val hd 'a : fn (list 'a) -> (maybe 'a)
+let hd [] = Nothing
+let hd (first :: _) = Just first

--- a/test_files/basic_type_signature.alp
+++ b/test_files/basic_type_signature.alp
@@ -27,8 +27,12 @@ let return x = Just x
 val apply 'a 'b : fn (fn 'a -> 'b) 'a -> 'b 
 let apply f x = f x
 
--- TODO: Infix functions (!)
+-- Infix functions
+val (<|) 'a 'b : fn (fn 'a -> 'b) 'a -> 'b
 let (<|) f x = apply f x
+
+val (|>) 'a 'b : fn 'a (fn 'a -> 'b) -> 'b
+let (|>) x f = f x
 
 -- Concrete typing of a polymorphic ADT
 val maybeDouble : fn (maybe int) -> (maybe int)

--- a/test_files/forward_symbol_reference.alp
+++ b/test_files/forward_symbol_reference.alp
@@ -8,10 +8,10 @@ let hof_fail () =
     apply add10 5
 
 let val_fail () =
-    10 + val
+    10 + value
 
 -- As these are both declared AFTER their usage, neither
 -- of the above functions will compile
 
 let add10 x = x + 10
-let val = 5
+let value = 5


### PR DESCRIPTION
Adds type signatures that use the same style as type specs on ADTs, e.g.

```f#
val apply 'a 'b : fn (fn 'a -> 'b) 'a -> 'b
let apply f x = f x
```
This also matches the syntax suggested by @danabr in https://github.com/alpaca-lang/alpaca/issues/133. There are many examples provided in https://github.com/lepoetemaudit/alpaca/blob/a70f1fc051616a376da63c65bfb313f02e8da246/test_files/basic_type_signature.alp

Note that we separate function arguments only by whitespace, not by `->`, and preceded by `fn`, unlike other MLs. I believe this syntax was chosen to better reflect the fact that functions in Alpaca are multi-arity, not single argument and auto-curried (currying happens at call-site). However, as has been discussed it is possible we might support the more ML style syntax in future alongside or in place of this one.