### PR TITLE
Fixes #196, rewrite unbound lambdas

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -662,4 +662,11 @@ type_signature_test() ->
     [M] = compile_and_load(Files, [test]),
     ?assertMatch(4, M:add(1, 3)).
 
+use_lambda_test() ->
+    Files = ["test_files/use_lambda.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(15, M:useLambda(5)),
+    ?assertMatch(13, M:useLambdaTuple(3)),
+    pd(M).
+
 -endif.

--- a/test_files/use_lambda.alp
+++ b/test_files/use_lambda.alp
@@ -1,0 +1,25 @@
+{- Tests for the compilation and use of a lambda defined and applied in the same
+   expression.  For fix of issue #196.
+
+   With thanks to https://github.com/lepoetemaudit for the initial test cases.
+ -}
+module use_lambda
+
+export useLambda, useLambdaTuple
+
+val apply 'a 'b : fn (fn 'a -> 'b) 'a -> 'b
+let apply f x = f x
+
+-- Used to fail:
+let useLambda x =
+  apply (fn y -> x + y) 10
+
+let useLambdaTuple x =
+  apply (fn (_, y) -> x + y) (:ignored, 10)
+
+let boundLambda x =
+  let lambda = (fn y -> x + y) in
+  apply lambda 10
+
+let useLet x =
+  apply (let f y = x + y in f) 10


### PR DESCRIPTION
Lambdas that occurred outside of explicit bindings weren't getting their
enclosed terms rewritten which led to typer failures.  Thanks to
@lepoetemaudit for catching this.