### PR TITLE
Allow expressions in list items

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -676,4 +676,16 @@ use_lambda_test() ->
     ?assertMatch(64, FFIFun(8)),
     pd(M).
 
+list_item_expression_test() ->
+    Files = ["test_files/list_items.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch([4, 17], M:getList({})),
+
+    Matrix = [[0, 0, 0, 0],
+              [0, 1, 0, 0],
+              [0, 0, 1, 0],
+              [0, 0, 0, 1]],
+    ?assertMatch(Matrix, M:getMatrix({})),
+    pd(M).
+
 -endif.

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -395,13 +395,13 @@ module_fun -> symbol '.' symbol :
   #alpaca_far_ref{line=L, module=binary_to_atom(Mod, utf8), name=Fun}.
 
 %% ----- Lists  ------------------------
-literal_cons_items -> expr : ['$1'].
-literal_cons_items -> expr ',' literal_cons_items: ['$1' | '$3'].
+literal_cons_items -> simple_expr : ['$1'].
+literal_cons_items -> simple_expr ',' literal_cons_items: ['$1' | '$3'].
 
 cons -> '[' ']' :
   {_, L} = '$1',
   {nil, L}.
-cons -> '[' expr ']' :
+cons -> '[' simple_expr ']' :
   {_, L} = '$3',
   #alpaca_cons{head='$2', tail={nil, L}, line=L}.
 cons -> term cons_infix term : #alpaca_cons{head='$1', tail='$3'}.

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -395,13 +395,13 @@ module_fun -> symbol '.' symbol :
   #alpaca_far_ref{line=L, module=binary_to_atom(Mod, utf8), name=Fun}.
 
 %% ----- Lists  ------------------------
-literal_cons_items -> term : ['$1'].
-literal_cons_items -> term ',' literal_cons_items: ['$1' | '$3'].
+literal_cons_items -> expr : ['$1'].
+literal_cons_items -> expr ',' literal_cons_items: ['$1' | '$3'].
 
 cons -> '[' ']' :
   {_, L} = '$1',
   {nil, L}.
-cons -> '[' term ']' :
+cons -> '[' expr ']' :
   {_, L} = '$3',
   #alpaca_cons{head='$2', tail={nil, L}, line=L}.
 cons -> term cons_infix term : #alpaca_cons{head='$1', tail='$3'}.

--- a/test_files/list_items.alp
+++ b/test_files/list_items.alp
@@ -1,0 +1,14 @@
+module list_items
+
+export getList, getMatrix
+
+let get_seventeen () = 17
+
+-- Simple expressions / function application
+let getList () = [2 + 2, get_seventeen ()]
+
+-- Sublists
+let getMatrix () = [ [0, 0, 0, 0]
+                   , [0, 1, 0, 0]
+                   , [0, 0, 1, 0]
+                   , [0, 0, 0, 1] ]


### PR DESCRIPTION
I noticed list items always required parens as it was requiring terms rather than expressions. This meant even simple literal lists such as `[1 + 2, 3 + 4]` wouldn't compile which isn't consistent with most langs.