### PR TITLE
Allow unsized binaries in construction

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -1764,7 +1764,10 @@ binary_test_() ->
                              value={'Symbol', #{line := 1, name := <<"a">>}}},
                           #alpaca_bits{
                              value={'Symbol', #{line := 1, name := <<"b">>}}}]}},
-        parse(alpaca_scanner:scan("<<a: size=8 type=int, b: size=8 type=int>>")))
+        parse(alpaca_scanner:scan("<<a: size=8 type=int, b: size=8 type=int>>"))),
+     ?_assertMatch(
+        {error, {1, alpaca_parser, unsized_binary_before_end}},
+        parse(alpaca_scanner:scan("match <<1>> with <<a: type=binary, b: type=utf8>> -> (a, b)")))
     ].
 
 string_test_() ->


### PR DESCRIPTION
I noticed some odd behavior when constructing binaries:

```ocaml
let a = <<"hello ">> in
let b = <<"world">> in
<<a: type=binary, b: type=binary>>
```
...would yield `<<"hworld">>`. The compiler was (rightfully) disallowing unsized binary bindings in pattern matches, as Erlang does, but it was also preventing them from working when constructing binaries in the above manner where it's really useful to be able to concatenate binaries in this fashion.

This PR changes the approach a little bit, validating match clauses in the parser, and otherwise allowing non-tail position binary symbols to use the default size. This makes the behaviour consistent with Erlang's, and best of all means we can define a string concat operator directly in Alpaca:

```fsharp
val (^^) : fn string string -> string
let (^^) str1 str2 =
  match <<str1: type=utf8, str2: type=utf8>> with
  | <<res: type=utf8>> -> res

let example () =
  "hello " ^^ "world" ^^ "!!!"
```