### PR TITLE
Reference cells in ETS instead of processes

### DIFF
--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -81,7 +81,7 @@
              | t_clause()
              | t_pid()
              | t_receiver()
-             | alpaca_typer:t_cell().  % a reference cell for a type.
+             | alpaca_typer:cell().  % a reference cell for a type.
 
 %%% ## ALPACA AST Nodes
 


### PR DESCRIPTION
After a lot of false starts I ended up taking a lazy approach here.  I
suspect it might be more efficient to carry the ETS table around in
the environment but threading that through everything starts to get
even messier.