### PR TITLE
Destructure terms with let bindings

### DIFF
--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -688,4 +688,11 @@ list_item_expression_test() ->
     ?assertMatch(Matrix, M:getMatrix({})),
     pd(M).
 
+destructuring_test() ->
+    Files = ["test_files/destructuring.alp"],
+    [M] = compile_and_load(Files, [test]),
+    ?assertMatch(11, M:test_it({})),
+    ?assertMatch(6, M:g({3, 3})),
+    pd(M).
+
 -endif.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -693,6 +693,9 @@ destructuring_test() ->
     [M] = compile_and_load(Files, [test]),
     ?assertMatch(11, M:test_it({})),
     ?assertMatch(6, M:g({3, 3})),
+    ?assertMatch(12, M:add_first_2_in_list([7, 5, 54, 32, not_an_int])),
+    ?assertError(if_clause, M:fail_on_tuple_without_1({2, "twelve"})),
+    ?assertMatch(<<"got 1!">>, M:fail_on_tuple_without_1({1, 1})),
     pd(M).
 
 -endif.

--- a/test_files/destructuring.alp
+++ b/test_files/destructuring.alp
@@ -1,7 +1,11 @@
 module destructuring
 
-export test_it, g
+export test_it, g, add_first_2_in_list, fail_on_tuple_without_1
 
 let f r = let {x=x, y=y} = r in x + y
 let g t = let (x, y) = t in f {x=x, y=y}
 let test_it () = g (5, 6)
+
+let add_first_2_in_list l = let x :: y :: _ = l in x + y
+
+let fail_on_tuple_without_1 t = let (1, _) = t in "got 1!"

--- a/test_files/destructuring.alp
+++ b/test_files/destructuring.alp
@@ -1,0 +1,7 @@
+module destructuring
+
+export test_it, g
+
+let f r = let {x=x, y=y} = r in x + y
+let g t = let (x, y) = t in f {x=x, y=y}
+let test_it () = g (5, 6)


### PR DESCRIPTION
Fixes #210, let's us do things like:

    let t = (1, 2) in
    let (one, _) = t in one * one