### PR TITLE
Problem: wildcard vars in multiple function heads fail compilation 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
   on:
     repo: alpaca-lang/alpaca
     skip_cleanup: true
-    tags: true
+    tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,10 @@ deploy:
   provider: releases
   api_key:
     secure: BAZxkGa98jJ6+JurzaUuGKO9pcuatjh0TMKLxSnYarVrikb9xWnM/wmmn2ajCvTgcl8wYppbQEpcgCJLb6m6ZI9L9ZBksii9ECacp2x2vDrGZ0QBhM/0tg9aHvUAhn7U2FRszqZwGnYlx/7Vb2hZ7Y8S3ojqLuuzturjRjtMkEPhLuLcHEAB/BPiqkdF/b0BRHGvYH2OhIyK4LKejSVL59sSRMzpt9x1c8r9+p6z12IHcsgek0vjQsmUJP3f4bE10FKRQkHBkzIOIqfSMFQ3+Ss/oVhWdHFRq47yfcPHiDAdU3UeVREHjMElRoqi6smJ7YSiyNMGWWS8ZmWjAi+nz/HNM4hdkCwy/GYlyjHjnjZR+fpHAyblHG3cphrpT6sBKZ2I9aC7sjoVIJWd6MShlaI929zKSxnqTzchPc8RL1qHD2vLaTtYiQ0tI7vJ01sCm9X2QpaYMvm46awhEmf3yl4b+Be0vUW/BLNvKBNQzmQ7Q+RaSrkA4USGu4Ilb4mH9jAX3evngJ0zkua/E4bWZ19oD0BJXoui2wzRiNhXJR8VCHVESji9R0Rp6yVhE3Mme0j1ssCMUDbQvBXptKe7HNDIpFcpGgTitWJZKXAE6+wUe8kadeMsU1nVhMkMFrVganrKZvieHIXWLsCYZqseGWOKkDYlaWvezljFbHzpGLU=
-  file: alpaca.tgz
+  file:
+    - alpaca_19.3.tgz
+    - alpaca_20.0.tgz
   on:
     repo: alpaca-lang/alpaca
     skip_cleanup: true
-    tags: false
+    tags: true

--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -20,6 +20,7 @@ Newest to oldest additions in each section.
 - enable internationalization and formatting of error messages, [[https://github.com/danabr][danabr]]
 
 ** Fixes
+- wildcard variables (the `_` variable) in function head matches are now renamed properly, [[https://github.com/j14159][j14159]]
 - partial record matching works, no more cycles in reference cells, [[https://github.com/j14159][j14159]]
 - type inferencer reference cells in ETS, no more processes, [[https://github.com/j14159][j14159]]
 - unsized binaries work correctly when constructing binaries, [[https://github.com/lepoetemaudit][lepoetemaudit]]

--- a/make-release.sh
+++ b/make-release.sh
@@ -22,5 +22,5 @@ cp code_of_conduct.md $REL_BASE
 cp $ALPACA_BEAMS/*.beam $BEAM_TARGET
 cp src/* $SRC_TARGET
 
-tar cvzf alpaca.tgz $REL_BASE
+tar cvzf alpaca_$TRAVIS_OTP_RELEASE.tgz $REL_BASE
 

--- a/test_files/function_pattern_args.alp
+++ b/test_files/function_pattern_args.alp
@@ -23,3 +23,11 @@ let double x = x * x
 let doubler x = my_map double (Some x)
 
 let double_maybe_x rec = my_map double (get_opt_x rec)
+
+{-
+ Mimics an issue I ran into working with elli and relatively specific pattern
+ matches.  Underscores/wildcards weren't getting renamed correctly due to the
+ code generator's environment changes being ignored when making patterns.
+ -}
+let handle_event :a b _ = :ok
+let handle_event _ _ _ = :whatever


### PR DESCRIPTION
The code generator wasn't properly folding over the changing
environment, leading to duplicated variable names.