### PR TITLE
Logical operators are reserved words

### DIFF
--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -372,7 +372,10 @@ keywords() ->
      <<"throw">>,
      <<"true">>,
      <<"false">>,
-     <<"fn">>
+     <<"fn">>,
+     <<"and">>,
+     <<"xor">>,
+     <<"or">>
     ]
     ++ base_types().
 

--- a/test/alpaca_SUITE.erl
+++ b/test/alpaca_SUITE.erl
@@ -177,7 +177,9 @@ g_type_record(Name, Params, KnownTypes, Size) ->
         {record, Keys, OfTypes}).
 
 g_record_key() ->
-    ?LET(N, integer(1, 255), g_sym(N)).
+    ?LET(N,
+	 integer(1, 255),
+	 ?SUCHTHAT(Name, g_sym(N), not lists:member(Name, keywords()))).
 
 to_binary([], Acc) ->
     g_sprinkle(lists:flatten(lists:reverse(Acc)));


### PR DESCRIPTION
`and`, `xor`, `or` as reserved words for PropEr tests.  Some periodic
CT failures because these weren't marked as such.