### PR TITLE
Show Alpaca source as OCaml on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.alp linguist-language=OCaml


### PR DESCRIPTION
This enables (close enough) syntax highlighting for Alpaca files on
GitHub. :)

We can remove this once GitHub supports Alpaca