### PR TITLE
Basic type alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,10 +551,6 @@ definite direction yet.
   hard based on what can be seen in the [LFE](https://github.com/lfe)
   code base.
 - support for typing anything other than a raw source file.
-- type annotations/restrictions/ascriptions.  Toying with the idea
-  of putting these in comments so that if the documentation is wrong
-  it yields a compiler error.
-- anonymous functions
 - side effects, like using `;` in OCaml for printing in a function
   with a non-unit result.
 
@@ -562,8 +558,6 @@ definite direction yet.
 This has been a process of learning-while-doing so there are a number of issues with
 the code, including but not limited to:
 
-- reference cells in the typer are processes that are never garbage
-  collected and it's pretty trigger-happy about creating them.
 - there's a lot of cruft around error handling that should all be
   refactored into some sort of basic monad-like thing.  This is
   extremely evident in `alpaca_ast_gen.erl` and `alpaca_typer.erl`.  Frankly

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -707,6 +707,11 @@ list_item_expression_test() ->
     ?assertMatch(Matrix, M:getMatrix({})),
     pd(M).
 
+future_ast_test() ->
+    Files = ["test_files/future_ast.alp"],
+    [M] = compile_and_load(Files, [test]),
+    pd(M).
+
 destructuring_test() ->
     Files = ["test_files/destructuring.alp"],
     [M] = compile_and_load(Files, [test]),

--- a/src/alpaca_ast.hrl
+++ b/src/alpaca_ast.hrl
@@ -246,6 +246,14 @@
          }).
 -type alpaca_type() :: #alpaca_type{}.
 
+-record(alpaca_type_alias, {
+          line=0 :: integer(),
+          module=undefined :: atom(),
+          name={type_name, -1, ""} :: alpaca_type_name(),
+          target=undefined :: alpaca_types()
+         }).
+-type alpaca_type_alias() :: #alpaca_type{}.
+
 -record(alpaca_type_apply, {
           type=undefined :: typ(),
           name=#type_constructor{} :: alpaca_constructor_name(),

--- a/src/alpaca_parser.yrl
+++ b/src/alpaca_parser.yrl
@@ -310,11 +310,19 @@ type -> type_declare poly_type_decl assign type_members :
   '$2'#alpaca_type{members='$4'}.
 type -> type_declare symbol assign type_members :
   {L, N} = symbol_line_name('$2'),
-  #alpaca_type{
-     line=L,
-     name={type_name, L, N},
-     vars=[],
-     members='$4'}.
+  %% Breaking this out to reduce repetition:
+  MakeType = fun() ->
+		    #alpaca_type{
+		       line=L,
+		       name={type_name, L, N},
+		       vars=[],
+		       members='$4'}
+	    end,
+  case '$4' of
+      [#alpaca_constructor{}] -> MakeType();
+      [M] -> #alpaca_type_alias{line=L, name={type_name, L, N}, target=M};
+      _   -> MakeType()
+  end.
 
 poly_type_decl -> symbol type_vars :
   {L, N} = symbol_line_name('$1'),

--- a/src/alpaca_printer.erl
+++ b/src/alpaca_printer.erl
@@ -189,7 +189,10 @@ format_type_def(#alpaca_type{vars=Vars, name={_, _, Name}, members=Members}) ->
                 format_type_arg(Other)
         end,
         Members))),
-    <<"type ", Name/binary, TypeVars/binary, " = ", MemberRepr/binary>>.
+    <<"type ", Name/binary, TypeVars/binary, " = ", MemberRepr/binary>>;
+format_type_def(#alpaca_type_alias{name={_, _, Name}, target=T}) ->
+    TargetRepr = format_type_arg(T),
+    <<"type ", Name/binary, " = ", TargetRepr/binary>>.
 
 format_module(#alpaca_module{functions=Funs,
                              name=Name,
@@ -222,6 +225,8 @@ format_module(#alpaca_module{functions=Funs,
 
     {PublicTypes, PrivateTypes} = lists:partition(
         fun(#alpaca_type{name={_, _, TName}}) ->
+                lists:member(TName, TypeExports);
+           (#alpaca_type_alias{name={_, _, TName}}) ->
                 lists:member(TName, TypeExports)
         end,
         ModTypes),
@@ -368,7 +373,7 @@ format_module_test() ->
           "---------------------\n\n"
           "val hello : string\n\n"
           "val add : fn int int -> int\n\n"
-          "val pair : fn int -> my_tuple\n\n"
+          "val pair : fn int -> (int, int)\n\n"
           "val identity 'a : fn 'a -> 'a\n"
         >>,
 

--- a/test_files/future_ast.alp
+++ b/test_files/future_ast.alp
@@ -1,0 +1,83 @@
+{-
+  Possible future Alpaca-native AST.  Mostly using this for testing right now as
+  trying things out has turned up a few bugs (e.g. record alias `binding` and
+  issue #234).
+ -}
+module ast
+
+export_type binding, module_ast, expr, symbol, opt
+
+export line
+
+export mod
+export int, int_val
+export float, float_val
+export string
+export bind, bind_body, bind_expr
+export symbol, symbol_name, symbol_rename
+
+type opt 'a = Some 'a | None
+
+type typ = TInt
+         | TFloat
+         | TString
+         | TArrow (list typ, typ)
+
+type binding = { line: int
+               , name: expr
+               , typ: opt typ
+               , bound: expr
+               , body: expr
+               }
+           
+{- These are the top-level AST nodes that modules are built from.
+ -}
+type module_ast = Module {line: int, name: atom}
+                | ModuleBinding binding
+                  
+let mod line name = Module {line=line, name=name}
+
+{- Expressions are only permitted inside of top-level bindings.
+ -}
+type expr = Int {line: int, value: int}
+          | Float {line: int, value: float}
+          | String {line: int, value: string}
+          | Symbol {line: int, name: string, original: opt string}
+          | Binding binding
+
+let line Float {line=l} = l
+let line Int {line=l} = l
+let line Symbol {line=l} = l
+let line Binding {line=l} = l
+let line String {line=l} = l
+
+
+let int line v = Int {line=line, value=v}
+
+let int_val Int {line=_, value=v} = v
+
+let float line v = Float {line=line, value=v}
+
+let float_val Float {line=_, value=v} = v
+
+let string line value = String {line=line, value=value}
+
+let bind name line bound body =
+  Binding { line=line
+          , name=name
+          , bound=bound
+          , body=body
+          , typ=None
+          }
+
+let bind_body (Binding b_rec) body = Binding {body=body | b_rec}
+
+let bind_expr (Binding b_rec) expr = Binding {bound=expr | b_rec}
+
+let symbol line name = Symbol {line=line, name=name, original=None}
+
+let symbol_name Symbol {name=n} = n
+
+let symbol_rename (Symbol {line=l, name=n}) new_name =
+  let orig = Some n in
+  Symbol {line=l, name=new_name, original=orig}


### PR DESCRIPTION
Fixes #234, at least mostly.  With these changes:

```elm
type r = {x: int, y: string}
```

Will be interpreted as a type alias (`#alpaca_type_alias{}`).  This makes some reuse easier, e.g. `binding` in `test_files/future_ast.alp`.  Previously these untagged single-member type declarations resulted in a full ADT which made instantiation both error prone and unnecessarily complex.

Note that this still produces an `#adt{}`:

```elm
type r 'x = {x: 'x, y: string}
```

I'm not sure how I'd like to change this yet, if at all.  There's a bit of a hack in this PR that gets around the ADT nature of this sort of type.