### PR TITLE
Fix record typing errors that incorrectly reported line 0

### DIFF
--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -287,6 +287,7 @@ group_funs(Funs, _ModuleName) ->
                                       line=L,
                                       bound_expr=#alpaca_fun{
                                                     arity=A,
+                                                    line=L,
                                                     versions=NewVs}}
               end
       end,

--- a/test/stacktrace_tests.erl
+++ b/test/stacktrace_tests.erl
@@ -55,9 +55,9 @@ fun_pattern_test() ->
 	run_for_trace(
 	  [{"fun_pattern.alp", alpaca_fun_pattern, Mod}],
 	  fun() -> alpaca_fun_pattern:f(2) end),
-    %% After adding a catch-all match case we would expect these annotations:
-    %%   [{file, "fun_pattern.alp"}, {line, 3}]
-    Expected = {alpaca_fun_pattern, f, 1, []},
+    %% Incorrect line number, see the following issue:
+    %% https://github.com/alpaca-lang/alpaca/issues/263
+    Expected = {alpaca_fun_pattern, f, 1, [{file, "fun_pattern.alp"}, {line, 4}]},
     ?assertMatch([Expected | _], Trace).
 
 throw_test() ->


### PR DESCRIPTION
Some line number reports are still incorrect but at least point to the
correct function now.  Please see the following issue for more detail:

https://github.com/alpaca-lang/alpaca/issues/263